### PR TITLE
UI overhaul: light/cream default theme, dark mode toggle, Lucide icons

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ export default [
       globals: {
         ...globals.browser,
         google: "readonly",
+        lucide: "readonly",
       },
     },
     rules: {

--- a/public/app.js
+++ b/public/app.js
@@ -11,6 +11,12 @@ const DRIVE_LAST_BACKUP_KEY = "driveLastBackup";
 // ─── Boot ────────────────────────────────────────────────────────────────────
 
 async function boot() {
+  // Apply saved theme before first render (default: light)
+  const savedTheme = localStorage.getItem("appTheme") || "light";
+  if (savedTheme === "dark") {
+    document.documentElement.dataset.theme = "dark";
+  }
+
   await db.openDB();
 
   // Restore Google Client ID and saved token if available
@@ -65,6 +71,7 @@ async function boot() {
   }
 
   renderNav();
+  renderHeaderIcons();
   navigate("home");
 }
 
@@ -73,24 +80,60 @@ async function boot() {
 function navigate(view) {
   currentView = view;
   renderNav();
+  renderHeaderIcons();
   renderView();
 }
 
 function renderNav() {
   const tabs = [
-    { id: "home",     icon: "🏠", label: "Home" },
-    { id: "routines", icon: "📋", label: "Routines" },
-    { id: "log",      icon: "📅", label: "Log" },
-    { id: "settings", icon: "⚙️",  label: "Settings" },
+    { id: "home",     icon: "home",         label: "Home" },
+    { id: "routines", icon: "dumbbell",      label: "Routines" },
+    { id: "log",      icon: "history",       label: "Log" },
+    { id: "settings", icon: "settings",      label: "Settings" },
   ];
 
   document.getElementById("nav").innerHTML = tabs
     .map(
       (t) => `<button class="${currentView === t.id ? "active" : ""}" onclick="app.navigate('${t.id}')">
-        <span class="icon">${t.icon}</span>${t.label}
+        <i data-lucide="${t.icon}"></i>${t.label}
       </button>`
     )
     .join("");
+
+  if (window.lucide) { lucide.createIcons(); }
+}
+
+function renderHeaderIcons() {
+  const reconnectNeeded = localStorage.getItem("driveReconnectNeeded");
+  const clientConfigured = localStorage.getItem("gClientId");
+  const signedIn = drive.isSignedIn();
+
+  const cloud = document.getElementById("header-cloud");
+  if (clientConfigured) {
+    if (signedIn) {
+      cloud.innerHTML = "<i data-lucide=\"cloud\"></i>";
+    } else if (reconnectNeeded) {
+      cloud.innerHTML = "<i data-lucide=\"cloud-off\"></i>";
+    } else {
+      cloud.innerHTML = "<i data-lucide=\"cloud\"></i>";
+    }
+  } else {
+    cloud.innerHTML = "";
+  }
+
+  const toggle = document.getElementById("theme-toggle");
+  const isDark = document.documentElement.dataset.theme === "dark";
+  toggle.innerHTML = isDark ? "<i data-lucide=\"sun\"></i>" : "<i data-lucide=\"moon\"></i>";
+
+  if (window.lucide) { lucide.createIcons(); }
+}
+
+function toggleTheme() {
+  const isDark = document.documentElement.dataset.theme === "dark";
+  const next = isDark ? "light" : "dark";
+  document.documentElement.dataset.theme = next;
+  localStorage.setItem("appTheme", next);
+  renderHeaderIcons();
 }
 
 function renderView() {
@@ -387,7 +430,7 @@ async function renderRoutines(el) {
           <div class="card-title" style="margin:0">${esc(r.name)}</div>
           <div style="display:flex;align-items:center;gap:8px">
             <span class="muted" style="font-size:.8rem">${exes.length} exercise${exes.length !== 1 ? "s" : ""}</span>
-            <span id="routine-chevron-${r.id}" style="color:var(--muted);transition:transform .2s;display:inline-block${open ? ";transform:rotate(180deg)" : ""}">▾</span>
+            <i data-lucide="chevron-down" id="routine-chevron-${r.id}" style="width:16px;height:16px;stroke:var(--muted);transition:transform .2s;display:inline-block${open ? ";transform:rotate(180deg)" : ""}"></i>
           </div>
         </div>
         <div id="routine-body-${r.id}" style="display:${open ? "block" : "none"}">
@@ -451,6 +494,7 @@ async function renderRoutines(el) {
   }
 
   el.innerHTML = html;
+  if (window.lucide) { lucide.createIcons(); }
 }
 
 // Modal state for routine editing
@@ -1269,6 +1313,7 @@ function toast(msg) {
 
 window.app = {
   navigate,
+  toggleTheme,
   startWorkout,
   finishWorkout,
   toggleExercise,

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-  <meta name="theme-color" content="#6366f1">
+  <meta name="theme-color" content="#2563eb">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <title>Exercise Tracker</title>
@@ -12,11 +12,17 @@
   <link rel="stylesheet" href="style.css">
   <!-- Google Identity Services (loaded async; Drive features require sign-in) -->
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <!-- Lucide icons -->
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 </head>
 <body>
   <div id="app">
     <header>
       <h1 id="page-title">Workout</h1>
+      <div class="header-icons">
+        <span class="header-cloud" id="header-cloud"></span>
+        <button class="theme-toggle" id="theme-toggle" onclick="app.toggleTheme()"></button>
+      </div>
     </header>
 
     <main id="main">

--- a/public/style.css
+++ b/public/style.css
@@ -2,6 +2,21 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
+  --bg:        #fdf8f2;
+  --surface:   #ffffff;
+  --border:    #e4d9cc;
+  --accent:    #2563eb;
+  --accent-dk: #1d4ed8;
+  --green:     #16a34a;
+  --red:       #dc2626;
+  --warn:      #ea8c1e;
+  --text:      #1c1208;
+  --muted:     #8a7660;
+  --radius:    12px;
+  --gap:       16px;
+}
+
+[data-theme="dark"] {
   --bg:        #0f172a;
   --surface:   #1e293b;
   --border:    #334155;
@@ -12,8 +27,6 @@
   --warn:      #f59e0b;
   --text:      #f1f5f9;
   --muted:     #94a3b8;
-  --radius:    12px;
-  --gap:       16px;
 }
 
 html, body {
@@ -53,6 +66,35 @@ header h1 {
   letter-spacing: -0.3px;
 }
 
+.header-icons {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.header-cloud svg {
+  width: 20px;
+  height: 20px;
+  stroke: var(--muted);
+  display: block;
+}
+
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.theme-toggle svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+}
+
 #main {
   flex: 1;
   overflow-y: auto;
@@ -89,7 +131,7 @@ nav button {
   transition: color 0.15s;
 }
 
-nav button .icon { font-size: 1.4rem; line-height: 1; }
+nav button svg { width: 22px; height: 22px; stroke: currentColor; margin-bottom: 1px; }
 nav button.active { color: var(--accent); }
 
 /* ── Cards ────────────────────────────────────────────────────────────────── */
@@ -99,6 +141,11 @@ nav button.active { color: var(--accent); }
   border-radius: var(--radius);
   padding: var(--gap);
   margin-bottom: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+[data-theme="dark"] .card {
+  box-shadow: none;
 }
 
 .card-title {
@@ -140,7 +187,7 @@ input[type="number"],
 select,
 textarea {
   width: 100%;
-  background: var(--bg);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
   color: var(--text);
@@ -200,7 +247,7 @@ textarea { resize: vertical; min-height: 70px; }
 
 /* ── Inline edit form ─────────────────────────────────────────────────────── */
 .inline-edit {
-  background: var(--bg);
+  background: var(--border);
   border-radius: 8px;
   padding: 12px;
   margin: 4px 0 8px;
@@ -263,7 +310,7 @@ canvas { max-width: 100%; }
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: var(--muted);
+  color: var(--warn);
   margin: 20px 0 10px;
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "exercise-tracker-v1";
+const CACHE = "exercise-tracker-v2";
 const ASSETS = [
   "./",
   "./index.html",


### PR DESCRIPTION
Replaces the dark slate/indigo default with a light cream theme and adds a persistent dark mode toggle. Driven by user preference for a warmer, less generic aesthetic.

## What changed

**Theming (`style.css`, `index.html`)**
- `:root` now defines the light theme (cream `#fdf8f2` bg, white cards, blue `#2563eb` accent, amber-orange `#ea8c1e` warn/section titles)
- `[data-theme="dark"]` on `<html>` activates the original dark slate/indigo palette
- Cards have a subtle `box-shadow` on light, none on dark
- `inline-edit` background uses `--border` token (was hardcoded `--bg`, which was unreadable on light)
- Form inputs use `--surface` background (was `--bg`)
- `.section-title` color changed from `--muted` to `--warn` (amber-orange on both themes)

**Icons (`index.html`, `app.js`, `eslint.config.js`)**
- Lucide icon library added via CDN (`unpkg.com/lucide@latest`)
- Bottom nav emoji replaced with Lucide SVGs: `home`, `dumbbell`, `history`, `settings`
- Routine expand/collapse chevrons replaced with Lucide `chevron-down` (animated via `transform: rotate`)
- `lucide` declared as ESLint readonly global alongside existing `google`

**Header (`index.html`, `app.js`)**
- New `renderHeaderIcons()` renders two icons into `.header-icons` on every navigate:
  - `cloud` / `cloud-off` (Lucide) reflects Google Drive connection state — shown only when a client ID is configured; `cloud-off` when `driveReconnectNeeded` is set in localStorage
  - Sun/moon toggle button calls `app.toggleTheme()`
- `toggleTheme()` flips `document.documentElement.dataset.theme` between `"light"` and `"dark"` and persists to `localStorage` key `appTheme`
- On boot, saved theme is applied before first render; default is light

**Service worker (`sw.js`)**
- Cache name bumped from `exercise-tracker-v1` to `exercise-tracker-v2` to force fresh assets

## Key implementation notes
- `lucide.createIcons()` is called after `renderNav()` and `renderRoutines()` since both inject `<i data-lucide="...">` elements into the DOM; guarded by `if (window.lucide)` to avoid errors if CDN fails to load
- The chevron element is manipulated directly by `toggleRoutine()` via `style.transform` — this works on the SVG element the same as it did on the old `<span>`
- `renderHeaderIcons()` is called from both `navigate()` and `boot()` so the cloud icon stays in sync after Drive sign-in/out

Closes #2