### PR TITLE
Add Health mode, multi-mode architecture, and app rename to SimpleFit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,14 @@
-# Agent Guide — Simple Exercise
+# Agent Guide — SimpleFit
 
 > **Note:** `CLAUDE.md` is a symlink to this file (`AGENTS.md`). All edits should be made directly to `AGENTS.md`.
 
 ## Project overview
 
-A mobile-first PWA exercise tracker hosted on GitHub Pages. No build step — vanilla ES modules served directly from `public/`. IndexedDB for local storage, Google Drive (appDataFolder) for cloud backup.
+A mobile-first PWA personal health tracker hosted on GitHub Pages. No build step — vanilla ES modules served directly from `public/`. IndexedDB for local storage, Google Drive (appDataFolder) for cloud backup.
 
+The app is organized into three **modes** (Exercise, Nutrition, Health), selected via a persistent segmented control in the header. Exercise and Health are live; Nutrition is a placeholder.
+
+- **App name:** SimpleFit (user-facing) — the repo and URL still use `simple-exercise`.
 - **Live URL:** `https://linuxmaier.github.io/simple-exercise/`
 - **Repo:** `git@github.com:linuxmaier/simple-exercise.git`
 
@@ -19,7 +22,7 @@ public/
   drive.js        Google Drive integration (GIS implicit OAuth flow)
   style.css       Light/cream mobile-first theme with dark mode (CSS custom properties)
   sw.js           Service worker — offline cache
-  manifest.json   PWA manifest (name: "Simple Exercise", short_name: "Exercise")
+  manifest.json   PWA manifest (name: "SimpleFit")
   icon.svg        Dumbbell SVG icon on indigo background
 eslint.config.js  ESLint 9 flat config (browser globals, double quotes, semi, 2-space indent)
 package.json      npm scripts: lint, lint:fix
@@ -40,23 +43,33 @@ All `public/` files are served verbatim by GitHub Pages. **Use relative paths ev
 ### `window.app` — inline onclick handlers
 Because views are built with HTML strings containing `onclick="app.foo()"`, all callable functions must be exported on `window.app` at the bottom of `app.js`. If you add a new function that is called from inline HTML, add it to the `window.app` object.
 
-### Views (currentView state)
-| Value | Header | Render function |
-|---|---|---|
-| `home` | Workout | `renderHome` |
-| `workout` | Active | `renderWorkout` |
-| `routines` | Routines | `renderRoutines` |
-| `log` | History | `renderLog` |
-| `settings` | Settings | `renderSettings` |
-| `exercise-history` | Progress | `renderExerciseHistory` |
-| `edit-session` | Edit Workout | `renderEditSession` |
+### Modes
+Top-level mode is tracked in `currentMode` (module scope) and persisted in `localStorage["currentMode"]`. The header shows a segmented control (`#mode-switcher` → `renderModeSwitcher()`) that switches modes via `setMode(mode)`. Each mode has its own bottom-nav tab set returned by `tabsForMode(mode)`. `Settings` is a shared tab available in every mode.
 
-Navigate with `navigate(viewName)` — sets `currentView`, re-renders nav and view.
+Modes: `"exercise"` (default), `"health"`, `"nutrition"` (placeholder only — no DB stores).
+
+### Views (currentView state)
+| Mode | Value | Render function |
+|---|---|---|
+| exercise | `home` | `renderHome` |
+| exercise | `workout` | `renderWorkout` |
+| exercise | `routines` | `renderRoutines` |
+| exercise | `log` | `renderLog` |
+| exercise | `exercise-history` | `renderExerciseHistory` |
+| exercise | `edit-session` | `renderEditSession` |
+| health | `health-today` | `renderHealthToday` |
+| health | `health-metrics` | `renderHealthMetrics` |
+| health | `health-metric` | `renderHealthMetricDetail` |
+| nutrition | `nutrition-home` | `renderNutritionHome` |
+| all | `settings` | `renderSettings` |
+
+Navigate with `navigate(viewName)` — sets `currentView`, re-renders mode switcher, nav and view. The page-title `<h1>` has been replaced by the mode switcher; views render their own section titles in-body.
 
 ## Data model (IndexedDB)
 
-DB name: `exercise-tracker`, version 1. All stores use `{ keyPath: "id", autoIncrement: true }`.
+DB name: `exercise-tracker`, version 2. All stores use `{ keyPath: "id", autoIncrement: true }`. The `onupgradeneeded` handler uses `objectStoreNames.contains()` guards so existing data survives v1→v2 upgrades.
 
+### v1 (Exercise) stores
 | Store | Key fields | Notes |
 |---|---|---|
 | `routines` | id, name, notes, updatedAt | |
@@ -64,6 +77,14 @@ DB name: `exercise-tracker`, version 1. All stores use `{ keyPath: "id", autoInc
 | `routineExercises` | id, routineId, exerciseId, exerciseName, defaultSets, defaultReps, defaultWeight, defaultDuration | join table; `defaultDuration` (seconds) used for timed exercises |
 | `sessions` | id, routineId, routineName, date, completedAt | open session has no `completedAt` |
 | `sessionExercises` | id, sessionId, exerciseId, exerciseName, type, sets, reps, weight, duration, setsCompleted, completed, routineExerciseId | `setsCompleted` tracks per-set progress (0..sets); `duration` in seconds for timed exercises; `routineExerciseId` links back to routine defaults (null for ad-hoc) |
+
+### v2 (Health) stores
+| Store | Key fields | Notes |
+|---|---|---|
+| `healthMetrics` | id, name, kind, unit, builtin, updatedAt | unique index on `name`; `kind` is `"numeric"` / `"dual"` / `"duration"`; `builtin: true` means seeded (Blood Pressure, Weight, Sleep) and cannot be deleted |
+| `healthReadings` | id, metricId, date (YYYY-MM-DD), recordedAt (ISO), value OR valueSystolic/valueDiastolic, notes, source, externalId | `source: "manual"` today; `externalId` reserved for future device ingestion dedup; pick `value` for numeric/duration metrics, `valueSystolic` + `valueDiastolic` for `dual` |
+
+On first entry into Health mode, `ensureHealthSeeded()` inserts the three built-in metrics if the store is empty. Built-ins can be renamed (on non-built-ins only — built-in name is read-only in the edit modal) and their unit/kind edited, but cannot be deleted.
 
 **Critical:** Never pass `id: undefined` to `db.*.save()` — IDB throws a DataError. Omit the `id` field entirely for new records: `{ name: "foo" }` not `{ id: undefined, name: "foo" }`.
 
@@ -92,9 +113,22 @@ db.sessionExercises.listForExercise(exerciseId)
 db.sessionExercises.save(record)
 db.sessionExercises.delete(id)
 
-db.exportAll()   // → full backup object
+db.healthMetrics.list()
+db.healthMetrics.get(id)
+db.healthMetrics.save(record)
+db.healthMetrics.delete(id)
+
+db.healthReadings.list()
+db.healthReadings.listForMetric(metricId)
+db.healthReadings.get(id)
+db.healthReadings.save(record)
+db.healthReadings.delete(id)
+
+db.exportAll()   // → full backup object (all v1 + v2 stores)
 db.importAll(data)  // clears all stores, then restores
 ```
+
+**When adding new stores:** update both `exportAll()` and `importAll()` in `db.js` — the store list in each is hardcoded and new stores will silently be excluded from backups otherwise.
 
 ## Drive integration (drive.js)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# Simple Exercise Tracker
+# SimpleFit
 
-A lightweight, mobile-first PWA for tracking workouts. Runs entirely in the browser — no server, no account required. Data lives in your browser's IndexedDB and can be backed up to Google Drive.
+A lightweight, mobile-first PWA for tracking workouts and health metrics. Runs entirely in the browser — no server, no account required. Data lives in your browser's IndexedDB and can be backed up to Google Drive.
+
+SimpleFit is organized into modes — switch between them using the segmented control in the header:
+
+- **Exercise** — routines, workouts, progress charts
+- **Health** — blood pressure, weight, sleep, and custom metrics (manual entry)
+- **Nutrition** — placeholder (coming soon)
 
 ## Screenshots
 

--- a/public/app.js
+++ b/public/app.js
@@ -3,11 +3,66 @@ import * as drive from "./drive.js";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
+let currentMode = "exercise"; // "exercise" | "nutrition" | "health"
 let currentView = "home";
 let activeSession = null; // { session, exercises: [sessionExercise & exerciseName] }
 let activeTimer = null; // { exId, setNum, remaining, intervalId }
+let viewingMetricId = null; // active metric in health-metric detail view
 
 const DRIVE_LAST_BACKUP_KEY = "driveLastBackup";
+const CURRENT_MODE_KEY = "currentMode";
+
+// ─── Modes ───────────────────────────────────────────────────────────────────
+
+const MODES = [
+  { id: "exercise",  label: "Exercise"  },
+  { id: "nutrition", label: "Nutrition" },
+  { id: "health",    label: "Health"    },
+];
+
+function tabsForMode(mode) {
+  switch (mode) {
+  case "exercise":
+    return [
+      { id: "home",     icon: "home",      label: "Home" },
+      { id: "routines", icon: "dumbbell",  label: "Routines" },
+      { id: "log",      icon: "history",   label: "Log" },
+      { id: "settings", icon: "settings",  label: "Settings" },
+    ];
+  case "health":
+    return [
+      { id: "health-today",   icon: "heart-pulse", label: "Today" },
+      { id: "health-metrics", icon: "activity",    label: "Metrics" },
+      { id: "settings",       icon: "settings",    label: "Settings" },
+    ];
+  case "nutrition":
+    return [
+      { id: "nutrition-home", icon: "utensils", label: "Food" },
+      { id: "settings",       icon: "settings", label: "Settings" },
+    ];
+  default:
+    return [];
+  }
+}
+
+function defaultViewForMode(mode) {
+  return tabsForMode(mode)[0].id;
+}
+
+function setMode(mode) {
+  if (mode === currentMode) { return; }
+  currentMode = mode;
+  localStorage.setItem(CURRENT_MODE_KEY, mode);
+  navigate(defaultViewForMode(mode));
+}
+
+function renderModeSwitcher() {
+  const host = document.getElementById("mode-switcher");
+  if (!host) { return; }
+  host.innerHTML = MODES.map((m) => `
+    <button class="seg-btn ${currentMode === m.id ? "active" : ""}" role="tab" aria-selected="${currentMode === m.id}" onclick="app.setMode('${m.id}')">${m.label}</button>
+  `).join("");
+}
 
 // ─── Boot ────────────────────────────────────────────────────────────────────
 
@@ -16,6 +71,12 @@ async function boot() {
   const savedTheme = localStorage.getItem("appTheme") || "light";
   if (savedTheme === "dark") {
     document.documentElement.dataset.theme = "dark";
+  }
+
+  // Restore last-used mode
+  const savedMode = localStorage.getItem(CURRENT_MODE_KEY);
+  if (savedMode && MODES.some((m) => m.id === savedMode)) {
+    currentMode = savedMode;
   }
 
   await db.openDB();
@@ -71,27 +132,24 @@ async function boot() {
     await checkDriveOnOpen();
   }
 
+  renderModeSwitcher();
   renderNav();
   renderHeaderIcons();
-  navigate("home");
+  navigate(defaultViewForMode(currentMode));
 }
 
 // ─── Navigation ──────────────────────────────────────────────────────────────
 
 function navigate(view) {
   currentView = view;
+  renderModeSwitcher();
   renderNav();
   renderHeaderIcons();
   renderView();
 }
 
 function renderNav() {
-  const tabs = [
-    { id: "home",     icon: "home",         label: "Home" },
-    { id: "routines", icon: "dumbbell",      label: "Routines" },
-    { id: "log",      icon: "history",       label: "Log" },
-    { id: "settings", icon: "settings",      label: "Settings" },
-  ];
+  const tabs = tabsForMode(currentMode);
 
   document.getElementById("nav").innerHTML = tabs
     .map(
@@ -139,16 +197,19 @@ function toggleTheme() {
 
 function renderView() {
   const main = document.getElementById("main");
-  const hdr  = document.getElementById("page-title");
 
   switch (currentView) {
-  case "home":     hdr.textContent = "Workout";   renderHome(main);     break;
-  case "workout":  hdr.textContent = "Active";    renderWorkout(main);  break;
-  case "routines": hdr.textContent = "Routines";  renderRoutines(main); break;
-  case "log":      hdr.textContent = "History";   renderLog(main);      break;
-  case "settings": hdr.textContent = "Settings";  renderSettings(main); break;
-  case "exercise-history": hdr.textContent = "Progress";    renderExerciseHistory(main); break;
-  case "edit-session":     hdr.textContent = "Edit Workout"; renderEditSession(main);     break;
+  case "home":             renderHome(main);              break;
+  case "workout":          renderWorkout(main);           break;
+  case "routines":         renderRoutines(main);          break;
+  case "log":              renderLog(main);               break;
+  case "settings":         renderSettings(main);          break;
+  case "exercise-history": renderExerciseHistory(main);   break;
+  case "edit-session":     renderEditSession(main);       break;
+  case "health-today":     renderHealthToday(main);       break;
+  case "health-metrics":   renderHealthMetrics(main);     break;
+  case "health-metric":    renderHealthMetricDetail(main); break;
+  case "nutrition-home":   renderNutritionHome(main);     break;
   }
 }
 
@@ -1457,34 +1518,45 @@ async function renderSettings(el) {
   }
 
   el.innerHTML = `
-    <div class="section-title">Notifications</div>
-    <div class="card">${notifCard}</div>
+    <div class="settings-section">
+      <div class="section-title">App · Google Drive Backup</div>
+      <div class="card">
+        <div class="field">
+          <label>Google OAuth Client ID</label>
+          <input type="text" id="client-id-input" value="${esc(savedId)}" placeholder="123....apps.googleusercontent.com">
+        </div>
+        <button class="btn btn-primary btn-sm" onclick="app.saveClientId()">Save Client ID</button>
 
-    <div class="section-title">Google Drive Backup</div>
-    <div class="card">
-      <div class="field">
-        <label>Google OAuth Client ID</label>
-        <input type="text" id="client-id-input" value="${esc(savedId)}" placeholder="123....apps.googleusercontent.com">
-      </div>
-      <button class="btn btn-primary btn-sm" onclick="app.saveClientId()">Save Client ID</button>
-
-      <div style="margin-top:16px;display:flex;gap:8px;flex-wrap:wrap">
-        ${signedIn
+        <div style="margin-top:16px;display:flex;gap:8px;flex-wrap:wrap">
+          ${signedIn
     ? "<button class=\"btn btn-ghost btn-sm\" onclick=\"app.driveSignOut()\">Sign Out of Google</button>"
     : "<button class=\"btn btn-primary btn-sm\" onclick=\"app.driveSignIn()\">Sign in to Google</button>"}
-        <button class="btn btn-green btn-sm" onclick="app.driveBackup()" ${signedIn ? "" : "disabled"}>Backup Now</button>
-        <button class="btn btn-ghost btn-sm" onclick="app.driveRestore()" ${signedIn ? "" : "disabled"}>Restore from Drive</button>
+          <button class="btn btn-green btn-sm" onclick="app.driveBackup()" ${signedIn ? "" : "disabled"}>Backup Now</button>
+          <button class="btn btn-ghost btn-sm" onclick="app.driveRestore()" ${signedIn ? "" : "disabled"}>Restore from Drive</button>
+        </div>
+        <div class="muted" style="font-size:.85rem;margin-top:12px">Last backup: ${lastBackupStr}</div>
       </div>
-      <div class="muted" style="font-size:.85rem;margin-top:12px">Last backup: ${lastBackupStr}</div>
+
+      <div class="section-title">App · Local Backup</div>
+      <div class="card">
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <button class="btn btn-ghost btn-sm" onclick="app.exportJSON()">Download JSON</button>
+          <button class="btn btn-ghost btn-sm" onclick="app.triggerImport()">Import JSON</button>
+        </div>
+        <input type="file" id="import-file" accept=".json" style="display:none" onchange="app.importJSON(this)">
+      </div>
     </div>
 
-    <div class="section-title">Local Backup</div>
-    <div class="card">
-      <div style="display:flex;gap:8px;flex-wrap:wrap">
-        <button class="btn btn-ghost btn-sm" onclick="app.exportJSON()">Download JSON</button>
-        <button class="btn btn-ghost btn-sm" onclick="app.triggerImport()">Import JSON</button>
+    <div class="settings-section">
+      <div class="section-title">Exercise · Notifications</div>
+      <div class="card">${notifCard}</div>
+    </div>
+
+    <div class="settings-section">
+      <div class="section-title">Health</div>
+      <div class="card">
+        <div class="muted" style="font-size:.9rem">Manage metrics and add readings from the Metrics and Today tabs in Health mode.</div>
       </div>
-      <input type="file" id="import-file" accept=".json" style="display:none" onchange="app.importJSON(this)">
     </div>`;
 }
 
@@ -1517,7 +1589,7 @@ async function reconnectDrive() {
     await drive.signIn();
     localStorage.removeItem("driveReconnectNeeded");
     await checkDriveOnOpen();
-    navigate("home");
+    navigate(defaultViewForMode(currentMode));
   } catch (err) {
     toast("Reconnect failed: " + err.message);
   }
@@ -1592,7 +1664,7 @@ async function driveRestore() {
     localStorage.setItem(DRIVE_LAST_BACKUP_KEY, new Date().toISOString());
     activeSession = null;
     toast("Restored from Drive");
-    navigate("home");
+    navigate(defaultViewForMode(currentMode));
   } catch (err) {
     toast("Restore failed: " + err.message);
   }
@@ -1623,7 +1695,7 @@ async function importJSON(input) {
     await db.importAll(data);
     activeSession = null;
     toast("Data imported");
-    navigate("home");
+    navigate(defaultViewForMode(currentMode));
   } catch (err) {
     toast("Import failed: " + err.message);
   }
@@ -1672,10 +1744,443 @@ function actionToast(html) {
   toastTimer = setTimeout(() => { el.classList.remove("show"); el.style.pointerEvents = "none"; }, 6000);
 }
 
+// ─── Health mode ─────────────────────────────────────────────────────────────
+
+const BUILTIN_METRICS = [
+  { name: "Blood Pressure", kind: "dual",     unit: "mmHg", builtin: true },
+  { name: "Weight",         kind: "numeric",  unit: "lb",   builtin: true },
+  { name: "Sleep",          kind: "duration", unit: "hr",   builtin: true },
+];
+
+async function ensureHealthSeeded() {
+  const existing = await db.healthMetrics.list();
+  if (existing.length > 0) { return; }
+  for (const m of BUILTIN_METRICS) {
+    await db.healthMetrics.save({ ...m });
+  }
+}
+
+function todayISODate() {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function formatReadingValue(reading, metric) {
+  if (metric.kind === "dual") {
+    return `${reading.valueSystolic}/${reading.valueDiastolic}`;
+  }
+  return String(reading.value);
+}
+
+function formatDateLabel(isoDate) {
+  if (!isoDate) { return ""; }
+  const today = todayISODate();
+  if (isoDate === today) { return "Today"; }
+  const y = new Date();
+  y.setDate(y.getDate() - 1);
+  const yyyy = y.getFullYear();
+  const mm = String(y.getMonth() + 1).padStart(2, "0");
+  const dd = String(y.getDate()).padStart(2, "0");
+  if (isoDate === `${yyyy}-${mm}-${dd}`) { return "Yesterday"; }
+  // Show as "Apr 12" for recent, "Apr 12, 2025" otherwise
+  const [yr, mo, day] = isoDate.split("-").map(Number);
+  const dt = new Date(yr, mo - 1, day);
+  const thisYear = new Date().getFullYear();
+  const opts = yr === thisYear
+    ? { month: "short", day: "numeric" }
+    : { month: "short", day: "numeric", year: "numeric" };
+  return dt.toLocaleDateString(undefined, opts);
+}
+
+function sortReadings(readings) {
+  // Newest first by date; tiebreak by recordedAt or id
+  return [...readings].sort((a, b) => {
+    if (a.date !== b.date) { return a.date < b.date ? 1 : -1; }
+    const at = a.recordedAt || "";
+    const bt = b.recordedAt || "";
+    if (at !== bt) { return at < bt ? 1 : -1; }
+    return (b.id || 0) - (a.id || 0);
+  });
+}
+
+async function renderHealthToday(el) {
+  await ensureHealthSeeded();
+  const metrics = await db.healthMetrics.list();
+  metrics.sort((a, b) => (a.id || 0) - (b.id || 0));
+
+  if (metrics.length === 0) {
+    el.innerHTML = "<div class=\"empty\">No metrics yet. Add one in the Metrics tab.</div>";
+    return;
+  }
+
+  const allReadings = await db.healthReadings.list();
+  const byMetric = new Map();
+  for (const r of allReadings) {
+    if (!byMetric.has(r.metricId)) { byMetric.set(r.metricId, []); }
+    byMetric.get(r.metricId).push(r);
+  }
+
+  let html = "<div class=\"section-title\">Today</div>";
+  for (const m of metrics) {
+    const readings = sortReadings(byMetric.get(m.id) || []);
+    const latest = readings[0];
+    const recent = readings.slice(1, 4);
+
+    html += `
+      <div class="card">
+        <div class="metric-card-head">
+          <button class="metric-name" onclick="app.viewMetric(${m.id})">${esc(m.name)}</button>
+          <button class="btn btn-primary btn-sm" onclick="app.addReading(${m.id})">+ Add</button>
+        </div>
+        ${latest ? `
+          <div class="metric-latest">${formatReadingValue(latest, m)} <span style="font-size:.85rem;color:var(--muted);font-weight:400">${esc(m.unit)}</span></div>
+          <div class="metric-latest-meta">${formatDateLabel(latest.date)}${latest.notes ? " · " + esc(latest.notes) : ""}</div>
+        ` : "<div class=\"muted\" style=\"font-size:.9rem;margin:8px 0 4px\">No readings yet.</div>"}
+        ${recent.length > 0 ? `
+          <div style="margin-top:8px">
+            ${recent.map((r) => `
+              <div class="reading-row">
+                <span class="reading-value">${formatReadingValue(r, m)} <span class="muted" style="font-weight:400">${esc(m.unit)}</span></span>
+                <span class="reading-date">${formatDateLabel(r.date)}</span>
+              </div>
+            `).join("")}
+          </div>
+        ` : ""}
+      </div>
+    `;
+  }
+
+  el.innerHTML = html;
+  if (window.lucide) { lucide.createIcons(); }
+}
+
+async function renderHealthMetrics(el) {
+  await ensureHealthSeeded();
+  const metrics = await db.healthMetrics.list();
+  metrics.sort((a, b) => (a.id || 0) - (b.id || 0));
+  const allReadings = await db.healthReadings.list();
+  const counts = new Map();
+  for (const r of allReadings) {
+    counts.set(r.metricId, (counts.get(r.metricId) || 0) + 1);
+  }
+
+  let html = `
+    <div class="section-title">Metrics</div>
+    <div class="card">
+      <button class="btn btn-primary btn-sm btn-full" onclick="app.showMetricModal()">+ New Metric</button>
+    </div>
+  `;
+
+  for (const m of metrics) {
+    const count = counts.get(m.id) || 0;
+    html += `
+      <div class="card">
+        <div class="metric-card-head">
+          <div>
+            <div class="card-title" style="margin-bottom:2px">${esc(m.name)}</div>
+            <div class="muted" style="font-size:.8rem">${esc(m.kind)} · ${esc(m.unit)} · ${count} reading${count === 1 ? "" : "s"}${m.builtin ? " · built-in" : ""}</div>
+          </div>
+          <button class="menu-btn" onclick="app.metricMenu(${m.id})">⋮</button>
+        </div>
+        <div class="inline-actions hidden" id="menu-metric-${m.id}">
+          <button class="btn btn-ghost btn-sm" onclick="app.showMetricModal(${m.id})">Edit</button>
+          <button class="btn btn-ghost btn-sm" onclick="app.viewMetric(${m.id})">View log</button>
+          ${m.builtin ? "" : `<button class="btn btn-danger btn-sm" onclick="app.deleteMetric(${m.id})">Delete</button>`}
+        </div>
+      </div>
+    `;
+  }
+
+  el.innerHTML = html;
+  if (window.lucide) { lucide.createIcons(); }
+}
+
+async function renderHealthMetricDetail(el) {
+  if (!viewingMetricId) {
+    navigate("health-today");
+    return;
+  }
+  const m = await db.healthMetrics.get(viewingMetricId);
+  if (!m) {
+    viewingMetricId = null;
+    navigate("health-today");
+    return;
+  }
+  const readings = sortReadings(await db.healthReadings.listForMetric(m.id));
+
+  let html = `
+    <div class="section-title">${esc(m.name)}</div>
+    <div class="card">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
+        <div class="muted" style="font-size:.85rem">${esc(m.kind)} · ${esc(m.unit)} · ${readings.length} reading${readings.length === 1 ? "" : "s"}</div>
+        <button class="btn btn-primary btn-sm" onclick="app.addReading(${m.id})">+ Add</button>
+      </div>
+    </div>
+  `;
+
+  if (readings.length === 0) {
+    html += "<div class=\"empty\">No readings yet.</div>";
+  } else {
+    html += "<div class=\"card\">";
+    for (const r of readings) {
+      html += `
+        <div class="reading-row" style="align-items:flex-start">
+          <div>
+            <div class="reading-value">${formatReadingValue(r, m)} <span class="muted" style="font-weight:400">${esc(m.unit)}</span></div>
+            ${r.notes ? `<div class="reading-notes">${esc(r.notes)}</div>` : ""}
+          </div>
+          <div style="text-align:right;display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+            <span class="reading-date">${formatDateLabel(r.date)}</span>
+            <div style="display:flex;gap:6px">
+              <button class="btn btn-ghost btn-sm" onclick="app.editReading(${r.id})">Edit</button>
+              <button class="btn btn-danger btn-sm" onclick="app.deleteReading(${r.id})">Delete</button>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+    html += "</div>";
+  }
+
+  el.innerHTML = html;
+}
+
+function viewMetric(metricId) {
+  viewingMetricId = metricId;
+  navigate("health-metric");
+}
+
+function metricMenu(metricId) {
+  toggleMenu(`metric-${metricId}`);
+}
+
+async function addReading(metricId) {
+  const m = await db.healthMetrics.get(metricId);
+  if (!m) { return; }
+  showReadingModal(m, null);
+}
+
+async function editReading(readingId) {
+  const r = await db.healthReadings.get(readingId);
+  if (!r) { return; }
+  const m = await db.healthMetrics.get(r.metricId);
+  if (!m) { return; }
+  showReadingModal(m, r);
+}
+
+function localTimeFromISO(isoStr) {
+  const d = new Date(isoStr);
+  return String(d.getHours()).padStart(2, "0") + ":" + String(d.getMinutes()).padStart(2, "0");
+}
+
+function currentLocalTime() {
+  const now = new Date();
+  return String(now.getHours()).padStart(2, "0") + ":" + String(now.getMinutes()).padStart(2, "0");
+}
+
+function showReadingModal(metric, existing) {
+  const modal = document.getElementById("modal");
+  const backdrop = document.getElementById("modal-backdrop");
+  const date = existing ? existing.date : todayISODate();
+  const time = existing && existing.recordedAt ? localTimeFromISO(existing.recordedAt) : currentLocalTime();
+  const notes = existing ? (existing.notes || "") : "";
+
+  let valueFields;
+  if (metric.kind === "dual") {
+    const sys = existing ? existing.valueSystolic : 120;
+    const dia = existing ? existing.valueDiastolic : 80;
+    valueFields = `
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+        <div class="field">
+          <label>Systolic</label>
+          <input type="text" id="m-rd-sys" value="${sys}" inputmode="numeric" pattern="[0-9]*">
+        </div>
+        <div class="field">
+          <label>Diastolic</label>
+          <input type="text" id="m-rd-dia" value="${dia}" inputmode="numeric" pattern="[0-9]*">
+        </div>
+      </div>`;
+  } else {
+    const val = existing ? existing.value : "";
+    valueFields = `
+      <div class="field">
+        <label>${esc(metric.name)} (${esc(metric.unit)})</label>
+        <input type="number" id="m-rd-val" value="${val}" step="any" inputmode="decimal">
+      </div>`;
+  }
+
+  modal.innerHTML = `
+    <div class="modal-title">${existing ? "Edit" : "New"} ${esc(metric.name)} reading</div>
+    ${valueFields}
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+      <div class="field">
+        <label>Date</label>
+        <input type="date" id="m-rd-date" value="${date}">
+      </div>
+      <div class="field">
+        <label>Time</label>
+        <input type="time" id="m-rd-time" value="${time}">
+      </div>
+    </div>
+    <div class="field">
+      <label>Notes (optional)</label>
+      <input type="text" id="m-rd-notes" value="${esc(notes)}">
+    </div>
+    <div style="display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost" onclick="app.closeModal()">Cancel</button>
+      <button class="btn btn-primary" onclick="app.saveReading(${metric.id}, ${existing ? existing.id : "null"})">Save</button>
+    </div>
+  `;
+  backdrop.classList.remove("hidden");
+}
+
+async function saveReading(metricId, readingId) {
+  const m = await db.healthMetrics.get(metricId);
+  if (!m) { return; }
+  const date = document.getElementById("m-rd-date").value;
+  const time = document.getElementById("m-rd-time").value;
+  const notes = document.getElementById("m-rd-notes").value.trim();
+  if (!date) { toast("Date is required"); return; }
+
+  const recordedAt = new Date(`${date}T${time || "00:00"}:00`).toISOString();
+
+  const record = {
+    metricId,
+    date,
+    notes,
+    source: "manual",
+    recordedAt,
+  };
+  if (readingId) { record.id = readingId; }
+
+  if (m.kind === "dual") {
+    const sys = parseFloat(document.getElementById("m-rd-sys").value);
+    const dia = parseFloat(document.getElementById("m-rd-dia").value);
+    if (isNaN(sys) || isNaN(dia)) { toast("Enter both values"); return; }
+    record.valueSystolic = sys;
+    record.valueDiastolic = dia;
+  } else {
+    const val = parseFloat(document.getElementById("m-rd-val").value);
+    if (isNaN(val)) { toast("Enter a value"); return; }
+    record.value = val;
+  }
+
+  await db.healthReadings.save(record);
+  closeModal();
+  toast("Reading saved");
+  renderView();
+}
+
+async function deleteReading(readingId) {
+  if (!confirm("Delete this reading?")) { return; }
+  await db.healthReadings.delete(readingId);
+  toast("Reading deleted");
+  renderView();
+}
+
+async function showMetricModal(metricId) {
+  const modal = document.getElementById("modal");
+  const backdrop = document.getElementById("modal-backdrop");
+  const existing = metricId ? await db.healthMetrics.get(metricId) : null;
+  const name = existing ? existing.name : "";
+  const kind = existing ? existing.kind : "numeric";
+  const unit = existing ? existing.unit : "";
+  const builtin = existing && existing.builtin;
+
+  modal.innerHTML = `
+    <div class="modal-title">${existing ? "Edit" : "New"} metric</div>
+    <div class="field">
+      <label>Name</label>
+      <input type="text" id="m-met-name" value="${esc(name)}" ${builtin ? "readonly" : ""} placeholder="e.g. Resting Heart Rate">
+    </div>
+    <div class="field">
+      <label>Kind</label>
+      <select id="m-met-kind" ${existing ? "disabled" : ""}>
+        <option value="numeric"  ${kind === "numeric"  ? "selected" : ""}>Numeric (single value)</option>
+        <option value="dual"     ${kind === "dual"     ? "selected" : ""}>Dual (e.g. systolic/diastolic)</option>
+        <option value="duration" ${kind === "duration" ? "selected" : ""}>Duration</option>
+      </select>
+    </div>
+    <div class="field">
+      <label>Unit</label>
+      <input type="text" id="m-met-unit" value="${esc(unit)}" placeholder="e.g. bpm, lb, kg, hr">
+    </div>
+    <div style="display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost" onclick="app.closeModal()">Cancel</button>
+      <button class="btn btn-primary" onclick="app.saveMetric(${existing ? existing.id : "null"})">Save</button>
+    </div>
+  `;
+  backdrop.classList.remove("hidden");
+}
+
+async function saveMetric(metricId) {
+  const name = document.getElementById("m-met-name").value.trim();
+  const kind = document.getElementById("m-met-kind").value;
+  const unit = document.getElementById("m-met-unit").value.trim();
+  if (!name) { toast("Name is required"); return; }
+  if (!unit) { toast("Unit is required"); return; }
+
+  const record = { name, kind, unit, builtin: false };
+  if (metricId) {
+    const prev = await db.healthMetrics.get(metricId);
+    if (prev) {
+      record.id = metricId;
+      record.builtin = prev.builtin || false;
+      // Built-ins keep their name regardless
+      if (prev.builtin) { record.name = prev.name; }
+    }
+  }
+
+  try {
+    await db.healthMetrics.save(record);
+  } catch (err) {
+    if (err && err.name === "ConstraintError") {
+      toast("A metric with that name already exists");
+      return;
+    }
+    throw err;
+  }
+  closeModal();
+  toast("Metric saved");
+  renderView();
+}
+
+async function deleteMetric(metricId) {
+  const m = await db.healthMetrics.get(metricId);
+  if (!m || m.builtin) { return; }
+  const readings = await db.healthReadings.listForMetric(metricId);
+  const msg = readings.length > 0
+    ? `Delete "${m.name}" and ${readings.length} reading${readings.length === 1 ? "" : "s"}?`
+    : `Delete "${m.name}"?`;
+  if (!confirm(msg)) { return; }
+  for (const r of readings) {
+    await db.healthReadings.delete(r.id);
+  }
+  await db.healthMetrics.delete(metricId);
+  toast("Metric deleted");
+  renderView();
+}
+
+// ─── Nutrition (placeholder) ─────────────────────────────────────────────────
+
+function renderNutritionHome(el) {
+  el.innerHTML = `
+    <div class="empty" style="padding-top:80px">
+      <div style="font-size:2rem;margin-bottom:12px">🍎</div>
+      <div style="font-weight:600;margin-bottom:6px">Nutrition tracking — coming soon</div>
+      <div style="font-size:.85rem">This mode is a placeholder. Check back later.</div>
+    </div>
+  `;
+}
+
 // ─── Expose to HTML ───────────────────────────────────────────────────────────
 
 window.app = {
   navigate,
+  setMode,
   toggleTheme,
   startWorkout,
   finishWorkout,
@@ -1724,6 +2229,15 @@ window.app = {
   exportJSON,
   triggerImport,
   importJSON,
+  viewMetric,
+  metricMenu,
+  addReading,
+  editReading,
+  saveReading,
+  deleteReading,
+  showMetricModal,
+  saveMetric,
+  deleteMetric,
 };
 
 boot();

--- a/public/db.js
+++ b/public/db.js
@@ -1,6 +1,8 @@
-// IndexedDB schema version
+// IndexedDB schema
+// v1 — exercise stores (routines, exercises, routineExercises, sessions, sessionExercises)
+// v2 — + health stores (healthMetrics, healthReadings)
 const DB_NAME = "exercise-tracker";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 let db = null;
 
@@ -15,28 +17,41 @@ export function openDB() {
     req.onupgradeneeded = (e) => {
       const d = e.target.result;
 
-      // Routines: named workout plans
-      const routines = d.createObjectStore("routines", { keyPath: "id", autoIncrement: true });
-      routines.createIndex("name", "name", { unique: false });
+      // v1 — exercise stores. Guarded so v1→v2 upgrades keep existing data.
+      if (!d.objectStoreNames.contains("routines")) {
+        const routines = d.createObjectStore("routines", { keyPath: "id", autoIncrement: true });
+        routines.createIndex("name", "name", { unique: false });
+      }
+      if (!d.objectStoreNames.contains("exercises")) {
+        const exercises = d.createObjectStore("exercises", { keyPath: "id", autoIncrement: true });
+        exercises.createIndex("name", "name", { unique: true });
+      }
+      if (!d.objectStoreNames.contains("routineExercises")) {
+        const routineExercises = d.createObjectStore("routineExercises", { keyPath: "id", autoIncrement: true });
+        routineExercises.createIndex("routineId", "routineId");
+        routineExercises.createIndex("exerciseId", "exerciseId");
+      }
+      if (!d.objectStoreNames.contains("sessions")) {
+        const sessions = d.createObjectStore("sessions", { keyPath: "id", autoIncrement: true });
+        sessions.createIndex("date", "date");
+        sessions.createIndex("routineId", "routineId");
+      }
+      if (!d.objectStoreNames.contains("sessionExercises")) {
+        const sessionExercises = d.createObjectStore("sessionExercises", { keyPath: "id", autoIncrement: true });
+        sessionExercises.createIndex("sessionId", "sessionId");
+        sessionExercises.createIndex("exerciseId", "exerciseId");
+      }
 
-      // Master exercise list
-      const exercises = d.createObjectStore("exercises", { keyPath: "id", autoIncrement: true });
-      exercises.createIndex("name", "name", { unique: true });
-
-      // Exercises within a routine (with defaults)
-      const routineExercises = d.createObjectStore("routineExercises", { keyPath: "id", autoIncrement: true });
-      routineExercises.createIndex("routineId", "routineId");
-      routineExercises.createIndex("exerciseId", "exerciseId");
-
-      // Workout sessions
-      const sessions = d.createObjectStore("sessions", { keyPath: "id", autoIncrement: true });
-      sessions.createIndex("date", "date");
-      sessions.createIndex("routineId", "routineId");
-
-      // Exercises performed in a session
-      const sessionExercises = d.createObjectStore("sessionExercises", { keyPath: "id", autoIncrement: true });
-      sessionExercises.createIndex("sessionId", "sessionId");
-      sessionExercises.createIndex("exerciseId", "exerciseId");
+      // v2 — health stores
+      if (!d.objectStoreNames.contains("healthMetrics")) {
+        const healthMetrics = d.createObjectStore("healthMetrics", { keyPath: "id", autoIncrement: true });
+        healthMetrics.createIndex("name", "name", { unique: true });
+      }
+      if (!d.objectStoreNames.contains("healthReadings")) {
+        const healthReadings = d.createObjectStore("healthReadings", { keyPath: "id", autoIncrement: true });
+        healthReadings.createIndex("metricId", "metricId");
+        healthReadings.createIndex("date", "date");
+      }
     };
 
     req.onsuccess = (e) => {
@@ -137,16 +152,37 @@ export const sessionExercises = {
   delete: (id) => remove("sessionExercises", id),
 };
 
+// ─── Health Metrics ──────────────────────────────────────────────────────────
+
+export const healthMetrics = {
+  list: () => all("healthMetrics"),
+  get: (id) => get("healthMetrics", id),
+  save: (m) => put("healthMetrics", { ...m, updatedAt: new Date().toISOString() }),
+  delete: (id) => remove("healthMetrics", id),
+};
+
+// ─── Health Readings ─────────────────────────────────────────────────────────
+
+export const healthReadings = {
+  list: () => all("healthReadings"),
+  listForMetric: (metricId) => all("healthReadings", "metricId", metricId),
+  get: (id) => get("healthReadings", id),
+  save: (r) => put("healthReadings", r),
+  delete: (id) => remove("healthReadings", id),
+};
+
 // ─── Export / Import ─────────────────────────────────────────────────────────
 
 export async function exportAll() {
   await openDB();
-  const [r, e, re, s, se] = await Promise.all([
-    routines.list(),
-    exercises.list(),
-    routineExercises.listForRoutine ? all("routineExercises") : [],
-    sessions.list(),
+  const [r, e, re, s, se, hm, hr] = await Promise.all([
+    all("routines"),
+    all("exercises"),
+    all("routineExercises"),
+    all("sessions"),
     all("sessionExercises"),
+    all("healthMetrics"),
+    all("healthReadings"),
   ]);
   return {
     version: DB_VERSION,
@@ -156,12 +192,22 @@ export async function exportAll() {
     routineExercises: re,
     sessions: s,
     sessionExercises: se,
+    healthMetrics: hm,
+    healthReadings: hr,
   };
 }
 
 export async function importAll(data) {
   await openDB();
-  const stores = ["routines", "exercises", "routineExercises", "sessions", "sessionExercises"];
+  const stores = [
+    "routines",
+    "exercises",
+    "routineExercises",
+    "sessions",
+    "sessionExercises",
+    "healthMetrics",
+    "healthReadings",
+  ];
   const t = db.transaction(stores, "readwrite");
 
   // Clear all stores first
@@ -175,6 +221,8 @@ export async function importAll(data) {
     routineExercises: data.routineExercises || [],
     sessions: data.sessions || [],
     sessionExercises: data.sessionExercises || [],
+    healthMetrics: data.healthMetrics || [],
+    healthReadings: data.healthReadings || [],
   };
 
   for (const [store, rows] of Object.entries(records)) {

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="theme-color" content="#2563eb">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>Exercise Tracker</title>
+  <title>SimpleFit</title>
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icon.svg">
   <link rel="stylesheet" href="style.css">
@@ -18,7 +18,7 @@
 <body>
   <div id="app">
     <header>
-      <h1 id="page-title">Workout</h1>
+      <div class="segmented-control" id="mode-switcher" role="tablist"></div>
       <div class="header-icons">
         <span class="header-cloud" id="header-cloud"></span>
         <button class="theme-toggle" id="theme-toggle" onclick="app.toggleTheme()"></button>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Simple Exercise",
-  "short_name": "Exercise",
-  "description": "Track workouts, routines, and progress",
+  "name": "SimpleFit",
+  "short_name": "SimpleFit",
+  "description": "Track workouts, health metrics, and progress",
   "start_url": "/simple-exercise/",
   "display": "standalone",
   "background_color": "#0f172a",

--- a/public/style.css
+++ b/public/style.css
@@ -66,6 +66,42 @@ header h1 {
   letter-spacing: -0.3px;
 }
 
+/* ── Segmented control (mode switcher) ────────────────────────────────────── */
+.segmented-control {
+  display: inline-flex;
+  background: var(--border);
+  border-radius: 99px;
+  padding: 3px;
+  gap: 2px;
+  flex: 1;
+  max-width: 320px;
+  margin-right: 12px;
+}
+
+.seg-btn {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--muted);
+  padding: 6px 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 99px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.seg-btn.active {
+  background: var(--surface);
+  color: var(--accent);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+[data-theme="dark"] .seg-btn.active {
+  box-shadow: none;
+}
+
 .header-icons {
   display: flex;
   align-items: center;
@@ -403,6 +439,72 @@ canvas { max-width: 100%; }
 .danger-text { color: var(--red); }
 .success-text { color: var(--green); }
 .muted { color: var(--muted); }
+
+/* ── Health: metric cards & reading rows ─────────────────────────────────── */
+.metric-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.metric-name {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  flex: 1;
+}
+
+.metric-latest {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  margin: 6px 0 2px;
+}
+
+.metric-latest-meta {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+
+.reading-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+}
+.reading-row:last-child { border-bottom: none; }
+
+.reading-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.reading-date {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.reading-notes {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-top: 2px;
+  font-style: italic;
+}
+
+.settings-section {
+  margin-bottom: 24px;
+}
 
 /* ── Notification banner ──────────────────────────────────────────────────── */
 .notif-banner {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "exercise-tracker-v3";
+const CACHE = "simplefit-v4";
 const ASSETS = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary

- **Multi-mode architecture**: persistent segmented control in the header switches between Exercise, Nutrition (placeholder), and Health modes; last-used mode is restored on reload
- **Health mode**: manual entry for Blood Pressure (dual systolic/diastolic), Weight, Sleep, and user-defined custom metrics; full CRUD for both metric definitions and readings; readings include editable date + time (stored as full ISO timestamp for future device ingestion)
- **App rename**: SimpleFit across manifest, title, and service worker cache
- **IndexedDB v2 migration**: idempotent upgrade handler preserves existing exercise data; new `healthMetrics` and `healthReadings` stores included in Drive/JSON backup round-trip
- **UX polish**: BP inputs use `type=text inputmode=numeric` for reliable numpad on iOS; Settings restructured into App / Exercise / Health sections; post-restore navigation fixed when triggered from non-exercise modes

## Test plan

- [ ] Existing exercise flows unchanged (start workout, complete sets, finish, view log, Drive backup/restore)
- [ ] Mode switcher visible on every screen; tapping changes nav + content; reload restores last mode
- [ ] Nutrition shows "Coming soon" placeholder
- [ ] Health — first visit seeds Blood Pressure, Weight, Sleep
- [ ] Add BP reading (120/78, today, note) — appears on Today and metric detail; time field defaults to current time and is editable; BP inputs open numpad
- [ ] Edit a reading — time field pre-populated from saved timestamp
- [ ] Delete a reading — removed from Today and detail views
- [ ] Create custom numeric metric, add reading, delete metric (cascades readings)
- [ ] Built-in metrics cannot be deleted; built-in names are read-only in edit modal
- [ ] `db.exportAll()` JSON contains `healthMetrics` and `healthReadings`; Drive backup → restore round-trips all data
- [ ] `npm run lint` passes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)