### PR TITLE
Fix #9: timer hangs and notification never fires on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ Each exercise in the active workout shows a segmented progress bar (one segment 
 Exercises have a `type` field: `"weight"` (default, reps-based) or `"timed"` (duration-based). Timed exercises show a countdown timer with Start/Stop controls in the workout view. The timer auto-completes the current set when it reaches zero, with vibration + a system notification (if enabled). Timer state is ephemeral (`activeTimer` in module scope) — not persisted to DB.
 
 ### Notifications
-Web Notifications API is used for timer completion alerts. Permission is requested from the Settings page and stored as `localStorage["notificationsEnabled"] = "true"`. `notificationsEnabled()` checks both the permission state and the localStorage flag. If a session contains timed exercises and notifications are not enabled, a banner is shown in the workout view linking to Settings. Key functions: `requestNotificationPermission()`, `disableNotifications()`.
+Web Notifications API is used for timer completion alerts. Permission is requested from the Settings page and stored as `localStorage["notificationsEnabled"] = "true"`. `notificationsEnabled()` checks both the permission state and the localStorage flag. If a session contains timed exercises and notifications are not enabled, a banner is shown in the workout view linking to Settings. Key functions: `requestNotificationPermission()`, `disableNotifications()`, `playAlert()`. Notifications are shown via `ServiceWorkerRegistration.showNotification()` (required on Android and iOS PWA, where `new Notification()` throws), with a `new Notification()` fallback for desktop browsers without a service worker.
 
 ### Update routine defaults prompt
 When a user edits sets/reps/weight/duration inline during a workout, `saveInlineEdit` compares the new values against the routine exercise defaults (via `routineExerciseId`). If they differ, an action toast appears offering to update the routine defaults. This only applies to exercises that came from a routine (not ad-hoc adds).
@@ -198,7 +198,7 @@ ESLint 9 flat config in `eslint.config.js`. Rules: double quotes, semicolons, 2-
 
 ## Service worker / caching
 
-`sw.js` caches all static assets under `CACHE = "simplefit-v4"`. **Bump the cache name when adding new assets** to the ASSETS array, otherwise the old service worker will serve stale files. Google API requests are passed through (not cached).
+`sw.js` caches all static assets under `CACHE = "simplefit-v5"`. **Bump the cache name whenever cached assets change** — both when adding new files to the ASSETS array and when you want returning users to pick up bugfixes in cached JS/CSS. Otherwise the old service worker will serve stale files. Google API requests are passed through (not cached).
 
 ## Deployment
 

--- a/public/app.js
+++ b/public/app.js
@@ -555,20 +555,13 @@ function startTimer(exId) {
       clearInterval(activeTimer.intervalId);
       const completedSetNum = activeTimer.setNum;
       activeTimer = null;
-      playAlert(ex.exerciseName);
-      tapSet(exId, completedSetNum);
-      // Re-render the timer area to show Start button again
-      const row = document.getElementById(`ex-${exId}`);
-      if (row) {
-        const actionsEl = row.querySelector(".ex-actions");
-        if (actionsEl) {
-          const btn = actionsEl.querySelector(".timer-active, .btn");
-          if (btn) {
-            const parent = btn.closest(".timer-active") || btn;
-            parent.outerHTML = `<button class="btn btn-ghost btn-sm" onclick="app.startTimer(${exId})">Start</button>`;
-          }
-        }
+      // Swap Stop → Start first so the UI is never left stuck if playAlert throws
+      const timerEl = document.getElementById(`timer-${exId}`);
+      if (timerEl) {
+        timerEl.outerHTML = `<button class="btn btn-ghost btn-sm" onclick="app.startTimer(${exId})">Start</button>`;
       }
+      tapSet(exId, completedSetNum);
+      playAlert(ex.exerciseName);
     }
   }, 1000);
 
@@ -631,15 +624,26 @@ function disableNotifications() {
   navigate("settings");
 }
 
-function playAlert(exerciseName) {
+async function playAlert(exerciseName) {
   if (navigator.vibrate) { navigator.vibrate([200, 100, 200]); }
-  if (notificationsEnabled()) {
-    new Notification("Set complete", {
-      body: exerciseName ? `${exerciseName} — time's up!` : "Timer finished",
-      icon: "./icon.svg",
-      silent: false,
-    });
-  }
+  if (!notificationsEnabled()) { return; }
+  const title = "Set complete";
+  const opts = {
+    body: exerciseName ? `${exerciseName} — time's up!` : "Timer finished",
+    icon: "./icon.svg",
+    silent: false,
+  };
+  // Prefer ServiceWorkerRegistration.showNotification — required on Android / iOS PWA,
+  // where `new Notification()` throws. Fall back to the constructor on platforms
+  // without a service worker.
+  try {
+    if ("serviceWorker" in navigator) {
+      const reg = await navigator.serviceWorker.ready;
+      await reg.showNotification(title, opts);
+      return;
+    }
+    new Notification(title, opts);
+  } catch { /* best-effort */ }
 }
 
 // ─── Update routine defaults ────────────────────────────────────────────────

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "simplefit-v4";
+const CACHE = "simplefit-v5";
 const ASSETS = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- Fixes #9 — on Android and iOS PWA, `new Notification()` throws a `TypeError` (those platforms require `ServiceWorkerRegistration.showNotification()`). The throw landed inside the timer's interval callback *after* `activeTimer` was nulled, stranding the Stop button and skipping the set-bar DB update.
- `playAlert` now prefers `ServiceWorkerRegistration.showNotification()`, falls back to `new Notification()` only when no SW is available, and is wrapped in try/catch so notifications are always best-effort.
- Reordered the timer-end handler so the Stop→Start button swap and `tapSet()` DB save run *before* `playAlert`, guaranteeing UI/DB consistency even if the notification path throws. Also simplified the button swap to the same `#timer-${exId}` lookup `stopTimer()` already uses.
- Bumped SW cache `simplefit-v4` → `simplefit-v5` so returning users pick up the fix on next load.
- Updated AGENTS.md to document the SW-notification requirement and broaden the cache-bump guidance.

## Test plan
- [ ] Desktop Chrome: enable notifications in Settings → run a timed exercise → verify notification fires, set bar fills, Stop button becomes Start
- [ ] Android Chrome (or installed PWA): same flow — pre-fix this hangs and fires no notification; post-fix both work
- [ ] Notifications disabled: timer still auto-completes and Stop→Start swap happens (vibration only)
- [ ] Interrupt mid-timer: tap Stop before expiry → timer halts, button reverts (sanity check)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)