### PR TITLE
Add content import and AI prompt templates (closes #8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,10 @@ db.importAll(data)  // clears all stores, then restores
 
 **When adding new stores:** update both `exportAll()` and `importAll()` in `db.js` — the store list in each is hardcoded and new stores will silently be excluded from backups otherwise.
 
+### `simplefit_import 1.0` — additive content imports
+
+A separate code path from `exportAll`/`importAll`, implemented in `app.js` (`validateImport`, `applyImport`, `importContent`). Content-import files carry a top-level `"simplefit_import": "1.0"` sentinel and may include any of `exercises`, `routines` (each with a nested `exercises` array whose entries reference exercises by `exerciseName`), and `healthMetrics`. Matching is case-insensitive on `name`; duplicates are skipped, never overwritten. Validation is all-or-nothing — nothing is written if any error is found, and cross-references (a routine entry naming an exercise that isn't in the file or the DB) abort the whole import before any writes. See `docs/import-format.md` for the full spec and `docs/ai-prompts/` for user-facing prompt templates that generate these files.
+
 ## Drive integration (drive.js)
 
 - **Scope:** `https://www.googleapis.com/auth/drive.appdata` (appDataFolder — hidden from user's Drive UI)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,13 @@ Backups are stored in your Google Drive's hidden **App Data** folder — they wo
 
 **Local JSON:**
 - Tap **Download JSON** in Settings to save a backup file to your device
-- Tap **Import JSON** to restore from a previously exported file
+- Tap **Import JSON** to restore from a previously exported file (**destructive** — replaces all local data)
+
+### Importing content (additive)
+
+To add routines, exercises, or health metrics **without** wiping your existing data, use **Import Content** in Settings → Local Backup. It accepts a `simplefit_import 1.0` JSON file. Duplicates (by name, case-insensitive) are skipped automatically.
+
+Need help building a file? See the AI prompt templates in [`docs/ai-prompts/`](./docs/ai-prompts/) — paste one into any AI chat and it'll interview you and output a ready-to-import file. Full format spec is in [`docs/import-format.md`](./docs/import-format.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ Backups are stored in your Google Drive's hidden **App Data** folder — they wo
 
 ### Importing content (additive)
 
-To add routines, exercises, or health metrics **without** wiping your existing data, use **Import Content** in Settings → Local Backup. It accepts a `simplefit_import 1.0` JSON file. Duplicates (by name, case-insensitive) are skipped automatically.
+To add routines, exercises, or health metrics **without** wiping your existing data, use **Import Content** in Settings → App · Import Content. It accepts a `simplefit_import 1.0` JSON file. Duplicates (by name, case-insensitive) are skipped automatically.
 
-Need help building a file? See the AI prompt templates in [`docs/ai-prompts/`](./docs/ai-prompts/) — paste one into any AI chat and it'll interview you and output a ready-to-import file. Full format spec is in [`docs/import-format.md`](./docs/import-format.md).
+Need help building a file? See the AI prompt templates in [`docs/ai-prompts/`](./docs/ai-prompts/) — paste one into any AI chat and it'll interview you and output a ready-to-import file. For an example of what that conversation may look like, see [`docs/ai-prompts/example-session.md`](./docs/ai-prompts/example-session.md). Full format spec is in [`docs/import-format.md`](./docs/import-format.md).
 
 ---
 

--- a/docs/ai-prompts/example-session.md
+++ b/docs/ai-prompts/example-session.md
@@ -1,0 +1,204 @@
+# Example session — designing a routine with Claude
+
+This is a real interview session using [`unified-routine-design.md`](./unified-routine-design.md) to design a 3×/week full-body routine with Claude. The prompt guides Claude to interview the user about experience, goals, schedule, equipment, and limitations before producing a `simplefit_import 1.0` JSON file.
+
+Use it to get a sense of:
+- how granular the interview gets (one question at a time, follow-ups welcome)
+- how user constraints (injuries, equipment, progression questions) shape the plan
+- what the final JSON output looks like in practice
+
+---
+
+**Human:**
+
+> use this prompt to design a routine for me
+
+*(attached the contents of `unified-routine-design.md`)*
+
+**Claude:**
+
+> Let's build your routine! I'll ask one question at a time.
+>
+> First up: What's your experience level?
+>
+> - Complete beginner (little to no training history)
+> - A few months of consistent training
+> - A year or more of training
+> - Advanced (3+ years, structured programming)
+
+**Human:**
+
+> I've had a few months consistent training.
+
+**Claude:**
+
+> Great, you've got a solid foundation to build on!
+>
+> What's your primary goal?
+
+**Human:**
+
+> Q: What's your primary goal?
+> A: I'm trying to build muscle mass, but the overall goal is my longterm health. I've been told that I need to lose some weight, and also help bring down my blood pressure.
+
+**Claude:**
+
+> That's a great combination of goals — building muscle actually supports all three: it boosts metabolism for fat loss, and regular resistance training is well-documented for improving blood pressure over time. We'll design around hypertrophy with that bigger picture in mind.
+>
+> How many days per week can you train, and roughly how long is each session?
+
+**Human:**
+
+> Q: How many days per week can you train?
+> A: 3 days
+>
+> Q: How long is a typical session?
+> A: 45–60 minutes
+
+**Claude:**
+
+> Perfect — 3 days is ideal for a full-body routine, which is actually great for muscle building and cardiovascular health at your stage.
+>
+> What equipment do you have access to?
+
+**Human:**
+
+> Q: What equipment do you have available? (Select all that apply)
+> A: Dumbbells, Barbell + plates, Machines, Cables, Kettlebells, Resistance bands, Bodyweight only
+
+**Claude:**
+
+> Great, you've got a full arsenal to work with — that gives us lots of good options!
+>
+> Do you have any injuries, limitations, or movements you need to avoid?
+
+**Human:**
+
+> Since I started exercising I've been getting cramps when I do crunches, though it's possible that's just because my core needs strengthening. Aside from that, if I exercise with bad form my shoulders can experience pain, so it's important to escalate resistance carefully.
+
+**Claude:**
+
+> Noted — we'll skip crunches and use core work that's gentler and more effective anyway (like dead bugs and planks). And we'll include form cues on any shoulder-loading movements and keep starting weights conservative.
+>
+> Last question — any exercise preferences or things you'd like to avoid?
+
+**Human:**
+
+> I think with form tips, I'd like guidance on how much to step up weights if we're starting too low. Like how much to add if I find an exercise easy, and how much I should be aiming to struggle at the end of the sets. In terms of anything to avoid, my gym does have machines but it's not like Planet Fitness where there's an infinite variety, so it would be good to use exercises that are simple or staples, or can be adapted to free weight if a machine isn't available.
+
+**Claude:**
+
+> Perfect guidance — I'll add progressive overload cues to every exercise note, and keep everything either barbell/dumbbell/cable-based so you're never stuck if a specific machine isn't free.
+>
+> Here's your routine — two alternating full-body sessions (A/B/A one week, B/A/B the next):
+
+```json
+{
+  "simplefit_import": "1.0",
+  "exercises": [
+    {
+      "name": "Barbell Back Squat",
+      "type": "weight",
+      "muscleGroup": "Legs",
+      "notes": "Feet shoulder-width, bar on upper traps. Break at hips and knees together, keep chest tall, knees track over toes. Aim for parallel or below. Add 5 lb when your last 2 reps of the final set feel like you had 2+ more in you. Target: those last 2 reps should be genuinely hard but not form-breaking."
+    },
+    {
+      "name": "Dumbbell Bench Press",
+      "type": "weight",
+      "muscleGroup": "Chest",
+      "notes": "Elbows at ~45° from your torso — not flared wide — this protects the shoulder joint. Press up and slightly inward. Add 2.5–5 lb per dumbbell when all sets feel easy with 2+ reps in reserve. Shoulder comfort is non-negotiable: if anything pinches, reduce the weight."
+    },
+    {
+      "name": "Dumbbell Bent-Over Row",
+      "type": "weight",
+      "muscleGroup": "Back",
+      "notes": "Hinge forward ~45°, brace your core, pull the dumbbell toward your hip (not your armpit). Drive with the elbow, not the hand. Add 5 lb when all sets feel easy. Last 2 reps of the final set should feel like work."
+    },
+    {
+      "name": "Dumbbell Romanian Deadlift",
+      "type": "weight",
+      "muscleGroup": "Hamstrings",
+      "notes": "Hinge at hips with a soft knee bend until you feel a hamstring stretch, then drive hips forward to stand. Keep the dumbbells close to your legs throughout. Add 5 lb when all reps feel easy with 2+ in reserve. Never round the lower back — form always beats weight."
+    },
+    {
+      "name": "Dead Bug",
+      "type": "weight",
+      "muscleGroup": "Core",
+      "notes": "Lie on your back, arms pointing at the ceiling, knees at 90°. Slowly lower one arm and the opposite leg toward the floor while pressing your lower back into the ground. Return and switch sides — that's one rep. Move deliberately, 3–4 seconds each way. No crunching motion. Progress by adding reps (aim for 12 then 16 before adding any load)."
+    },
+    {
+      "name": "Goblet Squat",
+      "type": "weight",
+      "muscleGroup": "Legs",
+      "notes": "Hold a dumbbell or kettlebell at chest height. The weight counterbalances you and makes it easier to squat upright and deep — great for reinforcing good mechanics. Add 5 lb when all sets feel easy with 2+ reps in reserve."
+    },
+    {
+      "name": "Dumbbell Overhead Press",
+      "type": "weight",
+      "muscleGroup": "Shoulders",
+      "notes": "Start lighter than you think — shoulder health comes first. Press from shoulder height with elbows slightly in front of the body (not flared wide). Only add weight when you complete all reps with zero shoulder discomfort and 2+ reps in reserve. Add just 2.5 lb at a time on this one."
+    },
+    {
+      "name": "Lat Pulldown",
+      "type": "weight",
+      "muscleGroup": "Back",
+      "notes": "Slightly wider than shoulder-width grip. Pull the bar to your upper chest by driving your elbows down and back. Avoid swinging or using momentum. No machine available? Substitute dumbbell bent-over rows or a resistance band pull-down from a door anchor. Add 5–10 lb when all sets feel easy."
+    },
+    {
+      "name": "Dumbbell Reverse Lunge",
+      "type": "weight",
+      "muscleGroup": "Legs",
+      "notes": "Step back rather than forward — reverse lunges are easier on the knees. Keep your front knee tracking over your toes and your torso upright. Add 5 lb per dumbbell when all sets feel easy with 2+ reps to spare."
+    },
+    {
+      "name": "Plank",
+      "type": "timed",
+      "muscleGroup": "Core",
+      "notes": "Forearms and toes, body in a straight line from head to heels. Squeeze your glutes and brace your abs as if bracing for a punch. When you can hold the full duration comfortably, add 10–15 seconds next session."
+    }
+  ],
+  "routines": [
+    {
+      "name": "Full Body A",
+      "notes": "Alternate with Full Body B each session: week 1 is A/B/A, week 2 is B/A/B. Rest 60–90 seconds between sets. Universal progression rule: if the last 2 reps of your final set feel easy (2+ reps clearly left in the tank), add weight next session. You should be working hard on those last reps — controlled struggle is the goal, not grinding with broken form.",
+      "exercises": [
+        { "exerciseName": "Barbell Back Squat",          "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Dumbbell Bench Press",        "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Dumbbell Bent-Over Row",      "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Dumbbell Romanian Deadlift",  "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Dead Bug",                    "defaultSets": 3, "defaultReps": 8,  "defaultWeight": 0 }
+      ]
+    },
+    {
+      "name": "Full Body B",
+      "notes": "Alternate with Full Body A each session. Same rest and progression rules apply. Pay extra attention to shoulder form on the overhead press — it's the one exercise where conservative weight increases matter most.",
+      "exercises": [
+        { "exerciseName": "Goblet Squat",            "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Dumbbell Overhead Press", "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Lat Pulldown",            "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Dumbbell Reverse Lunge",  "defaultSets": 3, "defaultReps": 10, "defaultWeight": 0 },
+        { "exerciseName": "Plank",                   "defaultSets": 3, "defaultReps": 1,  "defaultWeight": 0, "defaultDuration": 30 }
+      ]
+    }
+  ]
+}
+```
+
+> Save this as a `.json` file, then in SimpleFit open **Settings → App · Import Content** to load it.
+
+> A few extra notes worth knowing:
+>
+> **On progression:** all weights start at 0 so you fill them in on day one — pick a weight where you finish the set feeling like you could have done 2–3 more reps. That's your baseline. From there, the notes in each exercise tell you exactly when and how much to add.
+>
+> **On blood pressure:** the 60–90 second rest periods and the compound movements (squat, deadlift, row) are particularly good for cardiovascular adaptation over time. If your doctor has cleared you for exercise, this style of training is well-supported for improving BP with consistency.
+>
+> **On the core cramps:** Dead Bug and Plank avoid the spinal flexion that tends to trigger cramping with crunches. As your core strengthens, you can gradually increase Dead Bug reps and Plank duration.
+
+---
+
+## Notes for future reference
+
+- The interview ran six questions deep before Claude started generating. That's normal — the prompt instructs it not to produce JSON until it has enough context.
+- The user volunteered constraints the prompt didn't ask about (cramps on crunches, shoulder pain on bad form, guidance on progression). Claude folded those into the exercise `notes` fields. If you have similar constraints, mention them up front.
+- Claude proposed two routines (A/B split) because of the 3×/week frequency — the prompt allows 1–3 routines in a single file. Both were emitted in one JSON block, which imported cleanly as "Added 10 exercises, 2 routines."
+- A live copy of this conversation lives at <https://claude.ai/share/f45f4a2c-8be9-404c-bee2-e1fcfe57abc9> — kept here only as historical reference; the transcript above is the authoritative version since external share links can rot.

--- a/docs/ai-prompts/extend-existing-setup.md
+++ b/docs/ai-prompts/extend-existing-setup.md
@@ -1,0 +1,93 @@
+# Prompt: extend an existing SimpleFit setup
+
+**Who this is for:** users who already have routines and logged sessions in SimpleFit and want an AI to design *additions* — a new accessory day, a progression plan, timed core work, or fill a gap in their current program.
+
+**How to use:**
+
+1. In SimpleFit, go to **Settings → Local Backup → Download JSON**. Save the file.
+2. Copy the prompt below into any capable AI chat.
+3. Paste the contents of the file when the AI asks for them.
+4. Answer the AI's follow-up questions.
+5. Save the JSON the AI outputs to a new `.json` file.
+6. In SimpleFit, open **Settings → Local Backup → Import Content** and pick the file.
+
+The imported file only *adds* to your setup — it never modifies or deletes existing exercises, routines, sessions, or readings.
+
+---
+
+## Copy-paste prompt
+
+> You are an exercise programming assistant helping the user extend an existing SimpleFit setup. You will output a JSON file in the `simplefit_import 1.0` format that adds new exercises and/or routines to their app without modifying any existing data.
+>
+> **Start by asking the user to:**
+>
+> 1. Paste the contents of their SimpleFit export file (downloaded via **Settings → Local Backup → Download JSON**).
+> 2. State what they want you to help with — for example:
+>    - "Add an accessory/core day to my current split"
+>    - "Design a progression for the next 4 weeks"
+>    - "I want to add timed mobility work"
+>    - "Add an upper body routine; I only have lower body right now"
+>    - "Build a deload week"
+>
+> **Analyze the export first.** Before generating, summarize briefly what you see:
+>
+> - The existing routines and how many exercises each contains
+> - The exercises currently in their library (by muscle group if possible)
+> - If `sessions` and `sessionExercises` are populated, note recent volume or frequency patterns worth calling out
+> - Any obvious gaps (no hinge movements, no pulling, no core work, etc.)
+>
+> Then ask one or two clarifying questions if needed (days/week available, equipment changes, goal) — **but only if those aren't already clear from the export and the user's stated goal.**
+>
+> **When generating the JSON, follow these rules:**
+>
+> - Output only **additions**. Do not repeat existing routines or exercises that are already in the user's library.
+> - When a new routine references an existing exercise, use the **exact name** from the export (case-insensitive matching is supported, but exact spelling avoids ambiguity).
+> - Only include exercises in the file's `exercises[]` array if they're genuinely new to the user.
+> - Do not emit `sessions`, `sessionExercises`, or `healthReadings` — those keys are not part of `simplefit_import 1.0` and will be ignored, but including them clutters the output.
+> - If the user asked for a progression plan spanning multiple weeks, represent each week as a separate routine (e.g. `"Week 1 — Strength"`, `"Week 2 — Strength"`) rather than trying to encode progression inside one routine.
+> - For timed work (planks, holds, carries), set `"type": "timed"` on the exercise and `"defaultDuration"` (seconds) on the routine entry.
+>
+> After the JSON block, include exactly one line:
+>
+> > Save this as a `.json` file, then in SimpleFit open **Settings → Local Backup → Import Content** to load it.
+>
+> **Output format — `simplefit_import 1.0`:**
+>
+> ```json
+> {
+>   "simplefit_import": "1.0",
+>   "exercises": [
+>     {
+>       "name": "string (required, unique)",
+>       "type": "weight | timed (optional, default weight)",
+>       "muscleGroup": "string (optional)",
+>       "notes": "string (optional)"
+>     }
+>   ],
+>   "routines": [
+>     {
+>       "name": "string (required, unique)",
+>       "notes": "string (optional)",
+>       "exercises": [
+>         {
+>           "exerciseName": "must match an entry in exercises[] above OR an existing exercise in the user's library",
+>           "defaultSets": 3,
+>           "defaultReps": 10,
+>           "defaultWeight": 0,
+>           "defaultDuration": 45
+>         }
+>       ]
+>     }
+>   ]
+> }
+> ```
+>
+> Every top-level array is optional — include only what the user's request calls for.
+
+---
+
+## Tips for the user
+
+- SimpleFit de-duplicates by name (case-insensitive). If the AI accidentally emits an exercise you already have, it'll be skipped — no harm done.
+- If a new routine references an exercise the AI forgot to add and that you don't already have, the import will fail with a clear error. Ask the AI to include it.
+- You can run this prompt again later with an updated export to keep building on what you have.

--- a/docs/ai-prompts/unified-routine-design.md
+++ b/docs/ai-prompts/unified-routine-design.md
@@ -1,0 +1,89 @@
+# Prompt: design a new SimpleFit routine from scratch
+
+**Who this is for:** anyone starting a new SimpleFit setup — first-time lifter, returning to training, or just building a fresh routine. The AI will interview you about your goals and constraints, then produce a file you can import directly into SimpleFit.
+
+**How to use:**
+
+1. Copy the full prompt below into any capable AI chat (ChatGPT, Claude, Gemini, etc.).
+2. Answer the AI's interview questions.
+3. When it outputs a JSON block, save it to a `.json` file.
+4. In SimpleFit, open **Settings → Local Backup → Import Content** and pick the file.
+
+---
+
+## Copy-paste prompt
+
+> You are an exercise programming assistant. Your job is to design a training routine for the user and produce a single JSON file in the `simplefit_import 1.0` format, which the user will import into their SimpleFit app.
+>
+> **Before producing any JSON, interview the user.** Ask one question at a time and wait for their answer. Cover the following, in order:
+>
+> 1. Experience level — complete beginner, a few months of consistent training, a year or more, advanced.
+> 2. Primary goal — general fitness, strength, hypertrophy (muscle size), endurance, rehab, sport-specific.
+> 3. Days per week they can train, and typical session length in minutes.
+> 4. Equipment available — bodyweight only, dumbbells, barbell + plates, machines, cables, kettlebells, resistance bands.
+> 5. Injuries, limitations, or movements to avoid.
+> 6. Any preferences — exercises they want included, exercises they dislike, preferred split (full-body, upper/lower, push/pull/legs, etc.).
+>
+> After you have the answers, design the routine and output it as a **single JSON code block** in the format specified at the bottom of this prompt. Guidelines:
+>
+> - If the user trains 3 days/week or fewer, prefer a single full-body routine. For 4+ days, consider an upper/lower or push/pull/legs split (multiple routine entries in the same file).
+> - Pick a sensible number of exercises per session based on time constraints — roughly one exercise per 10–12 minutes including warmup.
+> - For each exercise, set reasonable `defaultSets` and `defaultReps`. For strength-focused work, lower reps (3–6); for hypertrophy, moderate (6–12); for endurance, higher (12–20).
+> - `defaultWeight` is in the user's preferred unit (they'll adjust in-app). If you don't know, set it to 0 so the user fills it in on day one.
+> - For isometric or timed work (planks, wall sits, dead hangs), use `"type": "timed"` on the exercise and `"defaultDuration"` in seconds on the routine entry.
+> - Put short coaching cues in the `notes` field of each exercise when useful (e.g. `"Keep chest tall, break at the hips"`).
+> - Use the same exact exercise name in `exercises[]` and in any routine's `exerciseName` reference.
+>
+> After the JSON block, include exactly one line:
+>
+> > Save this as a `.json` file, then in SimpleFit open **Settings → Local Backup → Import Content** to load it.
+>
+> **Output format — `simplefit_import 1.0`:**
+>
+> ```json
+> {
+>   "simplefit_import": "1.0",
+>   "exercises": [
+>     {
+>       "name": "string (required, unique)",
+>       "type": "weight | timed (optional, default weight)",
+>       "muscleGroup": "string (optional)",
+>       "notes": "string (optional)"
+>     }
+>   ],
+>   "routines": [
+>     {
+>       "name": "string (required, unique)",
+>       "notes": "string (optional)",
+>       "exercises": [
+>         {
+>           "exerciseName": "must match an entry in exercises[] above",
+>           "defaultSets": 3,
+>           "defaultReps": 10,
+>           "defaultWeight": 0,
+>           "defaultDuration": 45
+>         }
+>       ]
+>     }
+>   ],
+>   "healthMetrics": [
+>     {
+>       "name": "string (required, unique)",
+>       "kind": "numeric | dual | duration (required)",
+>       "unit": "string (optional, e.g. 'bpm', 'kg')"
+>     }
+>   ]
+> }
+> ```
+>
+> Every top-level array (`exercises`, `routines`, `healthMetrics`) is optional — include only what the user's situation calls for. For a brand-new routine, you'll almost always populate `exercises` and `routines`.
+>
+> Do not include a `healthMetrics` array unless the user specifically asked for health tracking.
+
+---
+
+## Tips for the user
+
+- The AI may ask clarifying questions in the middle of generation — that's fine, answer them and it will continue.
+- If the routine looks off, tell the AI what to change and ask it to regenerate the JSON.
+- SimpleFit imports are **additive**: if you already have a "Bench Press" exercise, the AI's duplicate will be skipped and the routine will link to your existing one. No data loss.

--- a/docs/examples/sample-import.json
+++ b/docs/examples/sample-import.json
@@ -1,0 +1,55 @@
+{
+  "simplefit_import": "1.0",
+  "exercises": [
+    {
+      "name": "Goblet Squat",
+      "muscleGroup": "Legs",
+      "notes": "Hold a dumbbell at chest height; sit down and up, chest tall."
+    },
+    {
+      "name": "Dumbbell Bench Press",
+      "muscleGroup": "Chest",
+      "notes": "Lower to mid-chest, pause briefly, press up without locking elbows hard."
+    },
+    {
+      "name": "One-Arm Dumbbell Row",
+      "muscleGroup": "Back",
+      "notes": "Flat back, drive elbow up and back. 3 sec eccentric."
+    },
+    {
+      "name": "Dead Bug",
+      "muscleGroup": "Core",
+      "notes": "Lower back pinned to floor; opposite arm + leg, slow."
+    },
+    {
+      "name": "Plank",
+      "type": "timed",
+      "muscleGroup": "Core",
+      "notes": "Ribs down, glutes squeezed. Breathe."
+    },
+    {
+      "name": "Farmer's Carry",
+      "type": "timed",
+      "muscleGroup": "Full body",
+      "notes": "Walk with heavy dumbbells, tall posture. Stop at time or grip failure."
+    },
+    {
+      "name": "Romanian Deadlift",
+      "muscleGroup": "Hamstrings",
+      "notes": "Hinge at the hips, soft knees, bar close to legs."
+    }
+  ],
+  "routines": [
+    {
+      "name": "Beginner Full-Body",
+      "notes": "3x/week. Rest 90 sec between sets.",
+      "exercises": [
+        { "exerciseName": "Goblet Squat",          "defaultSets": 3, "defaultReps": 10, "defaultWeight": 20 },
+        { "exerciseName": "Dumbbell Bench Press",  "defaultSets": 3, "defaultReps": 10, "defaultWeight": 25 },
+        { "exerciseName": "One-Arm Dumbbell Row",  "defaultSets": 3, "defaultReps": 10, "defaultWeight": 25 },
+        { "exerciseName": "Dead Bug",              "defaultSets": 3, "defaultReps": 12, "defaultWeight": 0 },
+        { "exerciseName": "Plank",                 "defaultSets": 3, "defaultDuration": 30 }
+      ]
+    }
+  ]
+}

--- a/docs/import-format.md
+++ b/docs/import-format.md
@@ -1,0 +1,135 @@
+# `simplefit_import 1.0` — content import format
+
+## Overview
+
+SimpleFit supports two kinds of JSON import:
+
+- **Import JSON** (Settings → Local Backup → Import JSON) — a **destructive** full-backup restore. Every IndexedDB store is cleared before the file is written. Used to move between devices.
+- **Import Content** (Settings → Local Backup → Import Content) — an **additive** content-only import. Adds exercises, routines, and health metrics alongside existing data. Never deletes, never overwrites. This document describes the file format.
+
+The two paths use different file shapes and are not interchangeable. Content-import files carry a top-level `"simplefit_import": "1.0"` sentinel; the full-backup export has a `"version": 2` field instead.
+
+## Top-level shape
+
+```json
+{
+  "simplefit_import": "1.0",
+  "exercises": [ ... ],
+  "routines": [ ... ],
+  "healthMetrics": [ ... ]
+}
+```
+
+- `"simplefit_import": "1.0"` — **required**. The import is rejected without it.
+- `exercises`, `routines`, `healthMetrics` — all **optional**; include any combination. Each, when present, must be an array (may be empty).
+
+## `exercises[]`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | Non-empty. Unique case-insensitively. |
+| `type` | `"weight"` or `"timed"` | no | Defaults to `"weight"`. |
+| `muscleGroup` | string | no | Freeform (e.g. `"Legs"`, `"Chest"`). |
+| `notes` | string | no | Coaching cues, form notes, etc. |
+
+## `routines[]`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | Non-empty. Unique case-insensitively. |
+| `notes` | string | no | |
+| `exercises` | array | yes | Non-empty. See below. |
+
+Each entry inside a routine's `exercises[]`:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `exerciseName` | string | yes | Must match (case-insensitively) either an exercise in the same file's `exercises[]` array, or an existing exercise in the app. |
+| `defaultSets` | number | no | Default 3. |
+| `defaultReps` | number | no | Default 10 for weight exercises; forced to 0 for timed. |
+| `defaultWeight` | number | no | Default 0. |
+| `defaultDuration` | number | no | Seconds. Only used for timed exercises; default 60. |
+
+## `healthMetrics[]`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `name` | string | yes | Non-empty. Unique case-insensitively. |
+| `kind` | `"numeric"`, `"dual"`, or `"duration"` | yes | `"numeric"` stores a single value; `"dual"` stores two values (e.g. systolic/diastolic); `"duration"` stores a duration in the metric's unit. |
+| `unit` | string | no | E.g. `"bpm"`, `"kg"`, `"hr"`. |
+
+## Dedup / merge semantics
+
+- Name matching is **case-insensitive**. `"Push-Up"` and `"push-up"` are the same exercise.
+- Duplicates against existing app data are **skipped, not errored**. The result summary tells the user how many were skipped.
+- Duplicates *within* the import file (between two entries of the same kind) are treated as a validation error — resolve them in the file before importing.
+- Existing records are never modified. If you want to change an existing routine, edit it in the app.
+
+## Validation rules
+
+Validation is all-or-nothing. If any rule fails, no records are written and the user sees a descriptive error.
+
+- The `"simplefit_import": "1.0"` sentinel must be present.
+- `exercises`, `routines`, `healthMetrics` must be arrays when present.
+- Each exercise must have a non-empty `name`; `type` if specified must be one of the allowed values.
+- Each routine must have a non-empty `name` and a non-empty `exercises` array.
+- Each routine-exercise entry's `exerciseName` must resolve to an exercise in the file or already in the app.
+- Each health metric must have a non-empty `name` and a valid `kind`.
+
+## Out of scope
+
+The content-import format does **not** carry:
+
+- Logged sessions (`sessions` / `sessionExercises`)
+- Health readings (`healthReadings`)
+- Deletions or updates to existing records
+
+If you need to migrate a full dataset, use **Download JSON** / **Import JSON** instead.
+
+## Examples
+
+### Minimal — one exercise
+
+```json
+{
+  "simplefit_import": "1.0",
+  "exercises": [
+    { "name": "Goblet Squat", "muscleGroup": "Legs", "notes": "Keep chest tall" }
+  ]
+}
+```
+
+### Full — exercises + routine + metric, mixing weight and timed
+
+```json
+{
+  "simplefit_import": "1.0",
+  "exercises": [
+    { "name": "Barbell Back Squat", "muscleGroup": "Legs" },
+    { "name": "Bench Press", "muscleGroup": "Chest" },
+    { "name": "Plank", "type": "timed", "muscleGroup": "Core" }
+  ],
+  "routines": [
+    {
+      "name": "Beginner Full-Body A",
+      "notes": "3x/week alternating with B",
+      "exercises": [
+        { "exerciseName": "Barbell Back Squat", "defaultSets": 3, "defaultReps": 5, "defaultWeight": 95 },
+        { "exerciseName": "Bench Press",         "defaultSets": 3, "defaultReps": 5, "defaultWeight": 65 },
+        { "exerciseName": "Plank",               "defaultSets": 3, "defaultDuration": 45 }
+      ]
+    }
+  ],
+  "healthMetrics": [
+    { "name": "Resting Heart Rate", "kind": "numeric", "unit": "bpm" }
+  ]
+}
+```
+
+## How to import
+
+1. In SimpleFit, go to **Settings → Local Backup**.
+2. Tap **Import Content** and pick the `.json` file.
+3. You'll see a result summary like `Added 3 exercises, 1 routine, 1 metric.` — or a validation error if the file was malformed.
+
+For help generating a file, see the AI prompt templates in [`docs/ai-prompts/`](./ai-prompts/).

--- a/public/app.js
+++ b/public/app.js
@@ -1547,7 +1547,23 @@ async function renderSettings(el) {
           <button class="btn btn-ghost btn-sm" onclick="app.exportJSON()">Download JSON</button>
           <button class="btn btn-ghost btn-sm" onclick="app.triggerImport()">Import JSON</button>
         </div>
+        <div class="muted" style="font-size:.8rem;margin-top:8px">
+          Backup/restore moves your entire dataset between devices. <strong>Import JSON</strong> replaces all local data with the contents of the file.
+        </div>
         <input type="file" id="import-file" accept=".json" style="display:none" onchange="app.importJSON(this)">
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <div class="section-title">App · Import Content</div>
+      <div class="card">
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <button class="btn btn-primary btn-sm" onclick="app.triggerImportContent()">Import Content</button>
+        </div>
+        <div class="muted" style="font-size:.8rem;margin-top:8px">
+          Adds exercises, routines, and metrics from a <code>simplefit_import 1.0</code> file without touching existing data. Duplicates (by name, case-insensitive) are skipped.
+        </div>
+        <input type="file" id="import-content-file" accept=".json" style="display:none" onchange="app.importContent(this)">
       </div>
     </div>
 
@@ -1703,6 +1719,273 @@ async function importJSON(input) {
   } catch (err) {
     toast("Import failed: " + err.message);
   }
+}
+
+// ─── Content import (additive — simplefit_import 1.0) ────────────────────────
+
+function triggerImportContent() {
+  document.getElementById("import-content-file").click();
+}
+
+async function importContent(input) {
+  const file = input.files[0];
+  if (!file) { return; }
+  try {
+    const text = await file.text();
+    const data = JSON.parse(text);
+    const { ok, errors } = validateImport(data);
+    if (!ok) {
+      if (errors.length > 1) { console.warn("simplefit_import validation errors:", errors); }
+      toast("Import failed: " + errors[0]);
+      return;
+    }
+    const counts = await applyImport(data);
+    const summary = buildSummary(counts);
+    actionToast(`${summary} <button class="btn btn-ghost btn-sm" style="margin-left:8px" onclick="app.dismissToast()">Dismiss</button>`);
+    navigate(defaultViewForMode(currentMode));
+  } catch (err) {
+    toast("Import failed: " + err.message);
+  } finally {
+    input.value = "";
+  }
+}
+
+function validateImport(data) {
+  const errors = [];
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return { ok: false, errors: ["File is not a JSON object"] };
+  }
+  if (data.simplefit_import !== "1.0") {
+    errors.push("Missing or unsupported simplefit_import version (expected \"1.0\")");
+  }
+  const validKinds = ["numeric", "dual", "duration"];
+  const validTypes = ["weight", "timed"];
+
+  const exercises = data.exercises;
+  if (exercises !== undefined) {
+    if (!Array.isArray(exercises)) {
+      errors.push("\"exercises\" must be an array");
+    } else {
+      const seen = new Set();
+      exercises.forEach((ex, i) => {
+        if (!ex || typeof ex !== "object") {
+          errors.push(`exercises[${i}] is not an object`);
+          return;
+        }
+        if (typeof ex.name !== "string" || !ex.name.trim()) {
+          errors.push(`exercises[${i}] is missing a non-empty name`);
+          return;
+        }
+        if (ex.type !== undefined && !validTypes.includes(ex.type)) {
+          errors.push(`exercises[${i}] (${ex.name}) has invalid type "${ex.type}"`);
+        }
+        const key = ex.name.trim().toLowerCase();
+        if (seen.has(key)) {
+          errors.push(`Duplicate exercise name within file: "${ex.name}"`);
+        }
+        seen.add(key);
+      });
+    }
+  }
+
+  const routines = data.routines;
+  if (routines !== undefined) {
+    if (!Array.isArray(routines)) {
+      errors.push("\"routines\" must be an array");
+    } else {
+      const seen = new Set();
+      routines.forEach((r, i) => {
+        if (!r || typeof r !== "object") {
+          errors.push(`routines[${i}] is not an object`);
+          return;
+        }
+        if (typeof r.name !== "string" || !r.name.trim()) {
+          errors.push(`routines[${i}] is missing a non-empty name`);
+          return;
+        }
+        if (!Array.isArray(r.exercises) || r.exercises.length === 0) {
+          errors.push(`routines[${i}] (${r.name}) must have a non-empty exercises array`);
+        } else {
+          r.exercises.forEach((entry, j) => {
+            if (!entry || typeof entry !== "object") {
+              errors.push(`routines[${i}].exercises[${j}] is not an object`);
+              return;
+            }
+            if (typeof entry.exerciseName !== "string" || !entry.exerciseName.trim()) {
+              errors.push(`routines[${i}].exercises[${j}] is missing exerciseName`);
+            }
+            ["defaultSets", "defaultReps", "defaultWeight", "defaultDuration"].forEach((f) => {
+              if (entry[f] !== undefined && typeof entry[f] !== "number") {
+                errors.push(`routines[${i}].exercises[${j}] ${f} must be a number`);
+              }
+            });
+          });
+        }
+        const key = r.name.trim().toLowerCase();
+        if (seen.has(key)) {
+          errors.push(`Duplicate routine name within file: "${r.name}"`);
+        }
+        seen.add(key);
+      });
+    }
+  }
+
+  const metrics = data.healthMetrics;
+  if (metrics !== undefined) {
+    if (!Array.isArray(metrics)) {
+      errors.push("\"healthMetrics\" must be an array");
+    } else {
+      const seen = new Set();
+      metrics.forEach((m, i) => {
+        if (!m || typeof m !== "object") {
+          errors.push(`healthMetrics[${i}] is not an object`);
+          return;
+        }
+        if (typeof m.name !== "string" || !m.name.trim()) {
+          errors.push(`healthMetrics[${i}] is missing a non-empty name`);
+          return;
+        }
+        if (!validKinds.includes(m.kind)) {
+          errors.push(`healthMetrics[${i}] (${m.name}) has invalid kind "${m.kind}" (must be numeric, dual, or duration)`);
+        }
+        const key = m.name.trim().toLowerCase();
+        if (seen.has(key)) {
+          errors.push(`Duplicate health metric name within file: "${m.name}"`);
+        }
+        seen.add(key);
+      });
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+async function applyImport(data) {
+  const counts = {
+    addedExercises: 0, skippedExercises: 0,
+    addedRoutines: 0, skippedRoutines: 0,
+    addedMetrics: 0, skippedMetrics: 0,
+  };
+
+  const [existingExercises, existingRoutines, existingMetrics] = await Promise.all([
+    db.exercises.list(),
+    db.routines.list(),
+    db.healthMetrics.list(),
+  ]);
+  const exerciseByLower = new Map(existingExercises.map((e) => [e.name.toLowerCase(), e]));
+  const routineByLower  = new Map(existingRoutines.map((r) => [r.name.toLowerCase(), r]));
+  const metricByLower   = new Map(existingMetrics.map((m) => [m.name.toLowerCase(), m]));
+
+  const exercisesToAdd = [];
+  for (const ex of data.exercises || []) {
+    const key = ex.name.trim().toLowerCase();
+    if (exerciseByLower.has(key)) { counts.skippedExercises++; continue; }
+    exercisesToAdd.push(ex);
+  }
+
+  const metricsToAdd = [];
+  for (const m of data.healthMetrics || []) {
+    const key = m.name.trim().toLowerCase();
+    if (metricByLower.has(key)) { counts.skippedMetrics++; continue; }
+    metricsToAdd.push(m);
+  }
+
+  const routinesToAdd = [];
+  for (const r of data.routines || []) {
+    const key = r.name.trim().toLowerCase();
+    if (routineByLower.has(key)) { counts.skippedRoutines++; continue; }
+    routinesToAdd.push(r);
+  }
+
+  // Cross-reference: every routine-to-add's entries must resolve to an existing exercise
+  // or to one staged for creation. Check before any writes so we abort atomically.
+  const plannedExerciseKeys = new Set(exercisesToAdd.map((e) => e.name.trim().toLowerCase()));
+  for (const r of routinesToAdd) {
+    for (const entry of r.exercises) {
+      const key = entry.exerciseName.trim().toLowerCase();
+      if (!exerciseByLower.has(key) && !plannedExerciseKeys.has(key)) {
+        throw new Error(`Routine "${r.name}" references unknown exercise "${entry.exerciseName}"`);
+      }
+    }
+  }
+
+  // Phase 2: writes in dependency order.
+  for (const ex of exercisesToAdd) {
+    const rec = { name: ex.name.trim() };
+    if (ex.type) { rec.type = ex.type; }
+    if (ex.muscleGroup) { rec.muscleGroup = ex.muscleGroup; }
+    if (ex.notes) { rec.notes = ex.notes; }
+    try {
+      const id = await db.exercises.save(rec);
+      const saved = await db.exercises.get(id);
+      exerciseByLower.set(saved.name.toLowerCase(), saved);
+      counts.addedExercises++;
+    } catch (err) {
+      if (err && err.name === "ConstraintError") {
+        // Race or unpredicted case collision — treat as skip and relink to existing.
+        counts.skippedExercises++;
+        const all = await db.exercises.list();
+        const existing = all.find((e) => e.name.toLowerCase() === rec.name.toLowerCase());
+        if (existing) { exerciseByLower.set(rec.name.toLowerCase(), existing); }
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  for (const r of routinesToAdd) {
+    const routineId = await db.routines.save({ name: r.name.trim(), notes: r.notes || "" });
+    for (let i = 0; i < r.exercises.length; i++) {
+      const entry = r.exercises[i];
+      const exRec = exerciseByLower.get(entry.exerciseName.trim().toLowerCase());
+      const isTimed = (exRec.type || "weight") === "timed";
+      const re = {
+        routineId,
+        exerciseId: exRec.id,
+        exerciseName: exRec.name,
+        defaultSets: typeof entry.defaultSets === "number" ? entry.defaultSets : 3,
+        defaultReps: isTimed ? 0 : (typeof entry.defaultReps === "number" ? entry.defaultReps : 10),
+        defaultWeight: typeof entry.defaultWeight === "number" ? entry.defaultWeight : 0,
+        defaultDuration: isTimed ? (typeof entry.defaultDuration === "number" ? entry.defaultDuration : 60) : null,
+        orderIndex: i,
+      };
+      await db.routineExercises.save(re);
+    }
+    counts.addedRoutines++;
+  }
+
+  for (const m of metricsToAdd) {
+    const rec = { name: m.name.trim(), kind: m.kind };
+    if (m.unit) { rec.unit = m.unit; }
+    await db.healthMetrics.save(rec);
+    counts.addedMetrics++;
+  }
+
+  return counts;
+}
+
+function buildSummary(c) {
+  const added = [];
+  if (c.addedExercises) { added.push(`${c.addedExercises} exercise${c.addedExercises === 1 ? "" : "s"}`); }
+  if (c.addedRoutines)  { added.push(`${c.addedRoutines} routine${c.addedRoutines === 1 ? "" : "s"}`); }
+  if (c.addedMetrics)   { added.push(`${c.addedMetrics} metric${c.addedMetrics === 1 ? "" : "s"}`); }
+
+  const skipped = [];
+  if (c.skippedExercises) { skipped.push(`${c.skippedExercises} exercise${c.skippedExercises === 1 ? "" : "s"}`); }
+  if (c.skippedRoutines)  { skipped.push(`${c.skippedRoutines} routine${c.skippedRoutines === 1 ? "" : "s"}`); }
+  if (c.skippedMetrics)   { skipped.push(`${c.skippedMetrics} metric${c.skippedMetrics === 1 ? "" : "s"}`); }
+
+  let msg;
+  if (added.length === 0 && skipped.length === 0) {
+    msg = "No changes.";
+  } else if (added.length === 0) {
+    msg = `Skipped ${skipped.join(", ")} (already existed).`;
+  } else if (skipped.length === 0) {
+    msg = `Added ${added.join(", ")}.`;
+  } else {
+    msg = `Added ${added.join(", ")}. Skipped ${skipped.join(", ")} (already existed).`;
+  }
+  return esc(msg);
 }
 
 // ─── Modal helpers ────────────────────────────────────────────────────────────
@@ -2233,6 +2516,8 @@ window.app = {
   exportJSON,
   triggerImport,
   importJSON,
+  triggerImportContent,
+  importContent,
   viewMetric,
   metricMenu,
   addReading,

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "simplefit-v5";
+const CACHE = "simplefit-v6";
 const ASSETS = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- Adds an additive **Import Content** flow in Settings (Settings → App · Import Content) that accepts a `simplefit_import 1.0` JSON file. Adds new exercises, routines, and health metrics alongside existing data; duplicates (case-insensitive on name) are skipped, never overwritten. Validation is all-or-nothing and runs before any DB writes.
- Adds two AI prompt templates under `docs/ai-prompts/` — `unified-routine-design.md` (cold start) and `extend-existing-setup.md` (user pastes their export for additions/progressions). Ships full `simplefit_import 1.0` format spec at `docs/import-format.md` and a sample file at `docs/examples/sample-import.json`.
- Service worker cache bumped `simplefit-v5` → `simplefit-v6` so returning users pick up the new `app.js`.

Closes #8

## Design decisions
- The existing destructive **Import JSON** (Local Backup) is unchanged and visually separated from the new additive **Import Content** (its own Settings section).
- Duplicates are always **skipped, never modified** — the principle is "never touch existing records." Fields like `notes`/`type`/`muscleGroup` on a duplicate-named exercise in the import are silently ignored.
- Cross-references inside the file (a routine entry naming an exercise that isn't in the file or the DB) abort the entire import before any writes, with a clear error toast.
- Picked two prompt templates over the four originally proposed in the issue: the new/intermediate split was collapsed into one unified template that interviews for experience level; "health metric setup" and "nutrition planning" were dropped as too thin / premature.

## Test plan
- [ ] Settings UI shows two distinct sections: **App · Local Backup** (Download/Import JSON) and **App · Import Content** (single primary button).
- [ ] Import `docs/examples/sample-import.json` — expect toast `Added 7 exercises, 1 routine.` Re-import the same file — expect `Skipped 7 exercises, 1 routine (already existed).`
- [ ] Case-insensitive dedup: create a file with `"Push-Up"` when DB has `"push-up"`; verify the new record is not added and any routine referencing `"PUSH-UP"` links to the existing exercise with its canonical casing.
- [ ] Timed exercise: sample file's `Plank` routine entry uses `defaultDuration: 30`; start the routine and confirm the timer starts at 30 s.
- [ ] Existing history untouched: before/after record counts for `sessions`, `sessionExercises`, `healthReadings` are identical (check via DevTools → IndexedDB).
- [ ] Validation edge cases each abort with zero writes: missing `simplefit_import` sentinel; `"simplefit_import": "2.0"`; `healthMetrics` entry with `kind: "bogus"`; routine referencing an unknown exercise; invalid JSON.
- [ ] Regression: existing **Import JSON** still prompts `confirm()` and restores a full backup.
- [ ] Service worker: after deploy, verify `simplefit-v6` active and `simplefit-v5` deleted.
- [ ] AI template smoke test: paste `docs/ai-prompts/unified-routine-design.md` into an AI chat, answer the interview, save output, import — expect a successful summary toast.
- [ ] `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)