### PR TITLE
Fix Drive reconnect banner only visible on Exercise home view

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -108,8 +108,7 @@ async function boot() {
         if (window.google) {
           clearInterval(interval);
           await tryInit();
-          // Re-render home to update the reconnect banner if needed
-          if (currentView === "home") { renderView(); }
+          renderHeaderIcons();
         }
       }, 100);
     }
@@ -167,6 +166,16 @@ function renderHeaderIcons() {
   const clientConfigured = localStorage.getItem("gClientId");
   const signedIn = drive.isSignedIn();
 
+  const banner = document.getElementById("drive-banner");
+  if (banner) {
+    if (reconnectNeeded && clientConfigured) {
+      banner.innerHTML = "<span>Drive disconnected</span>"
+        + "<button class=\"btn btn-warn btn-sm\" onclick=\"app.reconnectDrive()\">Reconnect</button>";
+    } else {
+      banner.innerHTML = "";
+    }
+  }
+
   const cloud = document.getElementById("header-cloud");
   if (clientConfigured) {
     if (signedIn) {
@@ -219,13 +228,6 @@ async function renderHome(el) {
   const routineList = await db.routines.list();
 
   let html = "";
-
-  if (localStorage.getItem("driveReconnectNeeded") && localStorage.getItem("gClientId")) {
-    html += `<div class="card" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;border-left:4px solid var(--warn)">
-      <span style="font-weight:600">Drive disconnected</span>
-      <button class="btn btn-warn btn-sm" onclick="app.reconnectDrive()">Reconnect</button>
-    </div>`;
-  }
 
   if (activeSession) {
     html += `<div class="card">

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,8 @@
       </div>
     </header>
 
+    <div id="drive-banner"></div>
+
     <main id="main">
       <div class="empty">Loading…</div>
     </main>

--- a/public/style.css
+++ b/public/style.css
@@ -506,6 +506,19 @@ canvas { max-width: 100%; }
   margin-bottom: 24px;
 }
 
+/* ── Drive reconnect banner ──────────────────────────────────────────────── */
+#drive-banner:not(:empty) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px var(--gap);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  border-left: 4px solid var(--warn);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
 /* ── Notification banner ──────────────────────────────────────────────────── */
 .notif-banner {
   background: var(--surface);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "simplefit-v6";
+const CACHE = "simplefit-v7";
 const ASSETS = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary

- The "Drive disconnected / Reconnect" banner was only rendered inside `renderHome()`, making it invisible when the user was in any other view (Health, Log, Routines, workout, Settings, etc.)
- Added a persistent `#drive-banner` div to `index.html` (between `<header>` and `<main>`, outside the scrollable content area), styled in `style.css`
- Moved banner management into `renderHeaderIcons()`, which is already called on every navigation — so the banner now appears and clears correctly from any mode or view
- Removed the inline banner from `renderHome()`; updated the GIS polling callback to call `renderHeaderIcons()` directly instead of conditionally re-rendering the whole view
- Bumped service worker cache to `simplefit-v7` to ensure users pick up the changed `index.html`, `app.js`, and `style.css`

closes #12

## Verification
- [x] Lint passes (`npm run lint`)
- [x] `driveReconnectNeeded` check no longer appears in `renderHome()` — banner is fully managed by `renderHeaderIcons()`
- [x] Service worker cache bumped to `simplefit-v7`
- [ ] With Drive configured but disconnected (`localStorage.setItem("driveReconnectNeeded","1")`), navigate to Health, Log, Routines, and Settings — confirm banner appears at the top of every view
- [ ] Click "Reconnect" and complete OAuth — confirm banner disappears and cloud icon returns to normal