### PR TITLE
Make routine Edit/Delete discoverable from collapsed card header

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -768,7 +768,12 @@ async function renderRoutines(el) {
           <div style="display:flex;align-items:center;gap:8px">
             <span class="muted" style="font-size:.8rem">${exes.length} exercise${exes.length !== 1 ? "s" : ""}</span>
             <i data-lucide="chevron-down" id="routine-chevron-${r.id}" style="width:16px;height:16px;stroke:var(--muted);transition:transform .2s;display:inline-block${open ? ";transform:rotate(180deg)" : ""}"></i>
+            <button class="menu-btn" onclick="event.stopPropagation();app.routineMenu(${r.id})">⋮</button>
           </div>
+        </div>
+        <div class="inline-actions hidden" id="menu-routine-${r.id}">
+          <button class="btn btn-ghost btn-sm" onclick="app.showRoutineModal(${r.id})">Edit Routine</button>
+          <button class="btn btn-danger btn-sm" onclick="app.deleteRoutine(${r.id})">Delete Routine</button>
         </div>
         <div id="routine-body-${r.id}" style="display:${open ? "block" : "none"}">
           ${r.notes ? `<div class="muted" style="font-size:.85rem;margin-bottom:10px">${esc(r.notes)}</div>` : ""}
@@ -797,11 +802,6 @@ async function renderRoutines(el) {
           </div>
           <div style="display:flex;justify-content:space-between;align-items:center">
             <button class="btn btn-ghost btn-sm" onclick="app.showAddExerciseToRoutine(${r.id})">+ Add Exercise</button>
-            <button class="menu-btn" onclick="app.routineMenu(${r.id})">⋮</button>
-          </div>
-          <div class="inline-actions hidden" id="menu-routine-${r.id}">
-            <button class="btn btn-ghost btn-sm" onclick="app.showRoutineModal(${r.id})">Edit Routine</button>
-            <button class="btn btn-danger btn-sm" onclick="app.deleteRoutine(${r.id})">Delete Routine</button>
           </div>
         </div>
       </div>`;


### PR DESCRIPTION
## Summary

- The routine ⋮ context menu (Edit Routine / Delete Routine) was buried inside the collapsible card body, invisible unless the user already knew to expand the card first
- Moves the ⋮ button to the routine card header row (alongside exercise count and chevron), so Edit and Delete are accessible without expanding
- Moves the `inline-actions` div outside the collapsible body so the menu renders correctly from the header
- Removes the now-redundant ⋮ button from the bottom of the expanded body

closes #13

## Verification

- [x] Lint passes (`npm run lint`)
- [ ] ⋮ button is visible on collapsed routine cards
- [ ] Tapping ⋮ on a collapsed card shows Edit Routine / Delete Routine
- [ ] Delete Routine prompts for confirmation then removes the routine
- [ ] ⋮ still works on expanded cards (regression)
- [ ] + Add Exercise still works inside expanded cards (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)